### PR TITLE
adding cronjob to cancel pending orders

### DIFF
--- a/Model/Cron/CancelOrderPending.php
+++ b/Model/Cron/CancelOrderPending.php
@@ -1,0 +1,127 @@
+<?php
+namespace Aplazo\AplazoPayment\Cron;
+
+use Magento\Framework\Api\FilterBuilder;
+use Magento\Framework\Api\Search\FilterGroup;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Sales\Api\OrderManagementInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+
+/**
+ * Class CancelOrderPending
+ */
+class CancelOrderPending
+{
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @var FilterBuilder
+     */
+    private $filterBuilder;
+
+    /**
+     * @var FilterGroup
+     */
+    private $filterGroup;
+
+    /**
+     * @var OrderManagementInterface
+     */
+    private $orderManagement;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     *  Time to cancel pending orders
+     */
+    const APLAZO_ORDER_CANCELLATION_TIME = 'payment/aplazo_payment/order_cancellation_time';
+
+    /**
+     * CancelOrderPending constructor.
+     *
+     * @param OrderRepositoryInterface $orderRepository
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     * @param FilterBuilder $filterBuilder
+     * @param FilterGroup $filterGroup
+     * @param OrderManagementInterface $orderManagement
+     * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        SearchCriteriaBuilder $searchCriteriaBuilder,
+        FilterBuilder $filterBuilder,
+        FilterGroup $filterGroup,
+        OrderManagementInterface $orderManagement,
+        ScopeConfigInterface $scopeConfig
+    ) {
+        $this->orderRepository       = $orderRepository;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->filterBuilder         = $filterBuilder;
+        $this->filterGroup           = $filterGroup;
+        $this->orderManagement       = $orderManagement;
+        $this->scopeConfig           = $scopeConfig;
+    }
+
+    /**
+     * @return mixed 
+     */
+    public function getOrderCancellationTime(){
+        $orderCancellationTime = self::APLAZO_ORDER_CANCELLATION_TIME;
+        if($orderCancellationTime == "" || $orderCancellationTime < 15)
+            return 30;
+        else
+            return $this->scopeConfig->getValue(self::APLAZO_ORDER_CANCELLATION_TIME); 
+    }
+    
+    /**
+     * @throws \Exception
+     */
+    public function execute()
+    {
+        $orderCancellationTime = $this->getOrderCancellationTime();
+        $today          = date("Y-m-d h:i:s");
+        $to             = strtotime('-'.$orderCancellationTime.' min', strtotime($today));
+        $to             = date('Y-m-d h:i:s', $to);
+
+        $filterGroupDate      = $this->filterGroup;
+        $filterGroupStatus    = clone($filterGroupDate);
+
+        $filterDate      = $this->filterBuilder
+            ->setField('updated_at')
+            ->setConditionType('to')
+            ->setValue($to)
+            ->create();
+        $filterStatus    = $this->filterBuilder
+            ->setField('status')
+            ->setConditionType('eq')
+            ->setValue('pending')
+            ->create();
+
+        $filterGroupDate->setFilters([$filterDate]);
+        $filterGroupStatus->setFilters([$filterStatus]);
+
+        $searchCriteria = $this->searchCriteriaBuilder->setFilterGroups(
+            [$filterGroupDate, $filterGroupStatus]
+        );
+        $searchResults  = $this->orderRepository->getList($searchCriteria->create());
+
+        /** @var Order $order */
+        foreach ($searchResults->getItems() as $order) {
+            $this->orderManagement->cancel($order->getId());
+        }
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -9,18 +9,18 @@
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-
                 <field id="title" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Title</label>
                 </field>
-
                 <field id="subtitle" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Sub-Title</label>
                 </field>
-
                 <field id="api_token" translate="label" type="obscure" sortOrder="33" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Api token</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                </field>
+                <field id="order_cancellation_time" translate="label" type="text" sortOrder="35" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Order cancellation time</label>
                 </field>
                 <field id="merchant_id" translate="label" type="obscure" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Merchant_id</label>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+    <group id="default">
+        <job name="aplazo_aplazopayment_cancel_order_pending" instance="Aplazo\AplazoPayment\Cron\CancelOrderPending" method="execute">
+            <schedule>* * * * *</schedule>
+        </job>
+    </group>
+</config>


### PR DESCRIPTION
Se generó un cronjob dentro del aplicativo para cancelar todas las órdenes pendientes de pago transcurrido un tiempo determinado.
Se puede asignar el tiempo desde el administrador de magento (valor numérico en minutos), en caso de no hacerlo el tiempo default es de 30 minutos.