### PR TITLE
Validate if product prices is null set to 0 instead

### DIFF
--- a/Model/Service/OrderService.php
+++ b/Model/Service/OrderService.php
@@ -231,7 +231,7 @@ class OrderService
                         "description" => $item->getDescription(),
                         "id" => $item->getProductId(),
                         "imageUrl" => '',
-                        "price" => $item->getRowTotal(),
+                        "price" => $item->getRowTotal() ?? 0,
                         "title" => $item->getName()
                     ];
                 }


### PR DESCRIPTION
This pull request introduces a minor improvement to the `createLoan` method in `OrderService.php` to handle cases where the item price might be null. Now, if `getRowTotal()` returns null, the price will default to 0, preventing potential issues with null values.

* Defaulted the `price` field to 0 if `$item->getRowTotal()` is null in the `createLoan` method of `OrderService.php`.