### PR TITLE
MG-262: Refunds idempotency added

### DIFF
--- a/Api/Data/RefundRequestInterface.php
+++ b/Api/Data/RefundRequestInterface.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Api\Data;
+
+use Magento\Framework\Api\ExtensibleDataInterface;
+
+interface RefundRequestInterface extends ExtensibleDataInterface
+{
+    public const ENTITY_ID = 'entity_id';
+    public const TYPE = 'type';
+    public const STATUS = 'status';
+    public const ORDER_INCREMENT_ID = 'order_increment_id';
+    public const ORDER_ID = 'order_id';
+    public const CREDITMEMO_ID = 'creditmemo_id';
+    public const RMA_ENTITY_ID = 'rma_entity_id';
+    public const RMA_ITEM_ID = 'rma_item_id';
+    public const ORDER_ITEM_ID = 'order_item_id';
+    public const QTY = 'qty';
+    public const AMOUNT_CENTS = 'amount_cents';
+    public const CURRENCY = 'currency';
+    public const REASON = 'reason';
+    public const REASON_HASH = 'reason_hash';
+    public const ITEMS_HASH = 'items_hash';
+    public const IDEMPOTENCY_KEY = 'idempotency_key';
+    public const PAYLOAD_JSON = 'payload_json';
+    public const RESPONSE_JSON = 'response_json';
+    public const APLAZO_REFUND_ID = 'aplazo_refund_id';
+    public const APLAZO_REFUND_STATUS = 'aplazo_refund_status';
+    public const RETRIES = 'retries';
+    public const LAST_ERROR = 'last_error';
+    public const NEXT_ATTEMPT_AT = 'next_attempt_at';
+    public const CREATED_AT = 'created_at';
+    public const UPDATED_AT = 'updated_at';
+
+    /**
+     * Identifier for this entity (maps to `entity_id`).
+     */
+    public function getId(): ?int;
+
+    /**
+     * Set identifier (maps to `entity_id`).
+     *
+     * Note: parameter is intentionally untyped to stay compatible with Magento model signatures.
+     *
+     * @param mixed $id
+     */
+    public function setId($id): self;
+
+    public function getType(): string;
+    public function setType(string $type): self;
+
+    public function getStatus(): string;
+    public function setStatus(string $status): self;
+
+    public function getOrderIncrementId(): string;
+    public function setOrderIncrementId(string $orderIncrementId): self;
+
+    public function getOrderId(): ?int;
+    public function setOrderId(?int $orderId): self;
+
+    public function getCreditmemoId(): ?int;
+    public function setCreditmemoId(?int $creditmemoId): self;
+
+    public function getRmaEntityId(): ?int;
+    public function setRmaEntityId(?int $rmaEntityId): self;
+
+    public function getRmaItemId(): ?int;
+    public function setRmaItemId(?int $rmaItemId): self;
+
+    public function getOrderItemId(): ?int;
+    public function setOrderItemId(?int $orderItemId): self;
+
+    public function getQty(): ?float;
+    public function setQty(?float $qty): self;
+
+    public function getAmountCents(): int;
+    public function setAmountCents(int $amountCents): self;
+
+    public function getCurrency(): ?string;
+    public function setCurrency(?string $currency): self;
+
+    public function getReason(): ?string;
+    public function setReason(?string $reason): self;
+
+    public function getReasonHash(): ?string;
+    public function setReasonHash(?string $reasonHash): self;
+
+    public function getItemsHash(): ?string;
+    public function setItemsHash(?string $itemsHash): self;
+
+    public function getIdempotencyKey(): string;
+    public function setIdempotencyKey(string $idempotencyKey): self;
+
+    public function getPayloadJson(): string;
+    public function setPayloadJson(string $payloadJson): self;
+
+    public function getResponseJson(): ?string;
+    public function setResponseJson(?string $responseJson): self;
+
+    public function getAplazoRefundId(): ?string;
+    public function setAplazoRefundId(?string $aplazoRefundId): self;
+
+    public function getAplazoRefundStatus(): ?string;
+    public function setAplazoRefundStatus(?string $aplazoRefundStatus): self;
+
+    public function getRetries(): int;
+    public function setRetries(int $retries): self;
+
+    public function getLastError(): ?string;
+    public function setLastError(?string $lastError): self;
+
+    public function getNextAttemptAt(): ?string;
+    public function setNextAttemptAt(?string $nextAttemptAt): self;
+
+    public function getCreatedAt(): ?string;
+    public function getUpdatedAt(): ?string;
+}
+

--- a/Api/Data/RefundRequestSearchResultsInterface.php
+++ b/Api/Data/RefundRequestSearchResultsInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Api\Data;
+
+use Magento\Framework\Api\SearchResultsInterface;
+
+interface RefundRequestSearchResultsInterface extends SearchResultsInterface
+{
+    /**
+     * @return \Aplazo\AplazoPayment\Api\Data\RefundRequestInterface[]
+     */
+    public function getItems();
+
+    /**
+     * @param \Aplazo\AplazoPayment\Api\Data\RefundRequestInterface[] $items
+     * @return $this
+     */
+    public function setItems(array $items);
+}
+

--- a/Api/RefundQueueManagementInterface.php
+++ b/Api/RefundQueueManagementInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Api;
+
+interface RefundQueueManagementInterface
+{
+    /**
+     * Process queued refunds (best-effort).
+     *
+     * @param int $batchSize
+     * @return int Number of items attempted
+     */
+    public function process(int $batchSize = 20): int;
+}
+

--- a/Api/RefundRequestRepositoryInterface.php
+++ b/Api/RefundRequestRepositoryInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Api;
+
+use Aplazo\AplazoPayment\Api\Data\RefundRequestInterface;
+use Aplazo\AplazoPayment\Api\Data\RefundRequestSearchResultsInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+interface RefundRequestRepositoryInterface
+{
+    /**
+     * @throws AlreadyExistsException
+     * @throws LocalizedException
+     */
+    public function save(RefundRequestInterface $refundRequest): RefundRequestInterface;
+
+    /**
+     * @throws NoSuchEntityException
+     */
+    public function getById(int $entityId): RefundRequestInterface;
+
+    public function getList(SearchCriteriaInterface $searchCriteria): RefundRequestSearchResultsInterface;
+
+    /**
+     * @throws LocalizedException
+     */
+    public function delete(RefundRequestInterface $refundRequest): bool;
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function deleteById(int $entityId): bool;
+}
+

--- a/Console/Command/CancelOrdersCommand.php
+++ b/Console/Command/CancelOrdersCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Console\Command;
+
+use Aplazo\AplazoPayment\Cron\CancelOrders;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CancelOrdersCommand extends Command
+{
+    public function __construct(private CancelOrders $cancelOrdersCron)
+    {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setName('aplazo:orders:cancel')
+            ->setDescription('Run Aplazo cancel orders cron manually');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->cancelOrdersCron->execute();
+        $output->writeln('<info>Done.</info>');
+        return Command::SUCCESS;
+    }
+}
+

--- a/Console/Command/ProcessRefundQueueCommand.php
+++ b/Console/Command/ProcessRefundQueueCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Console\Command;
+
+use Aplazo\AplazoPayment\Api\RefundQueueManagementInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ProcessRefundQueueCommand extends Command
+{
+    private const OPTION_BATCH_SIZE = 'batch-size';
+
+    public function __construct(private RefundQueueManagementInterface $refundQueueManagement)
+    {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setName('aplazo:refund:process')
+            ->setDescription('Process queued Aplazo refunds (manual trigger)')
+            ->addOption(
+                self::OPTION_BATCH_SIZE,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Max items to attempt in this run',
+                20
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $batchSize = (int)$input->getOption(self::OPTION_BATCH_SIZE);
+        if ($batchSize <= 0) {
+            $batchSize = 20;
+        }
+
+        $attempted = $this->refundQueueManagement->process($batchSize);
+        $output->writeln('<info>Attempted:</info> ' . $attempted);
+
+        return Command::SUCCESS;
+    }
+}
+

--- a/Controller/Adminhtml/RefundRequest/Index.php
+++ b/Controller/Adminhtml/RefundRequest/Index.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Controller\Adminhtml\RefundRequest;
+
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\View\Result\PageFactory;
+
+class Index extends Action
+{
+    public const ADMIN_RESOURCE = 'Aplazo_AplazoPayment::aplazo_refund_queue';
+
+    public function __construct(
+        Context $context,
+        private PageFactory $resultPageFactory
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute()
+    {
+        $page = $this->resultPageFactory->create();
+        $page->setActiveMenu(self::ADMIN_RESOURCE);
+        $page->getConfig()->getTitle()->prepend(__('Aplazo refunds'));
+        return $page;
+    }
+}
+

--- a/Controller/Adminhtml/RefundRequest/MassCancelRetries.php
+++ b/Controller/Adminhtml/RefundRequest/MassCancelRetries.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Controller\Adminhtml\RefundRequest;
+
+use Aplazo\AplazoPayment\Model\RefundRequest;
+use Aplazo\AplazoPayment\Model\ResourceModel\RefundRequest\CollectionFactory;
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Ui\Component\MassAction\Filter;
+
+class MassCancelRetries extends Action
+{
+    public const ADMIN_RESOURCE = 'Aplazo_AplazoPayment::aplazo_refund_queue';
+
+    public function __construct(
+        Context $context,
+        private Filter $filter,
+        private CollectionFactory $collectionFactory
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute()
+    {
+        $collection = $this->filter->getCollection($this->collectionFactory->create());
+
+        $updated = 0;
+        foreach ($collection as $request) {
+            /** @var RefundRequest $request */
+            $request->setStatus(RefundRequest::STATUS_CANCELLED);
+            $request->setNextAttemptAt(null);
+            $request->setLastError('Cancelled manually by admin user.');
+            $request->save();
+            $updated++;
+        }
+
+        $this->messageManager->addSuccessMessage(__('Cancelled retries for %1 request(s).', $updated));
+
+        $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
+        return $resultRedirect->setPath('aplazo/refundrequest/index');
+    }
+}
+

--- a/Cron/ProcessRefundQueue.php
+++ b/Cron/ProcessRefundQueue.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Cron;
+
+use Aplazo\AplazoPayment\Api\RefundQueueManagementInterface;
+
+class ProcessRefundQueue
+{
+    public function __construct(
+        private RefundQueueManagementInterface $refundQueueManagement
+    ) {
+    }
+
+    public function execute(): void
+    {
+        $this->refundQueueManagement->process();
+    }
+}
+

--- a/Model/RefundLock.php
+++ b/Model/RefundLock.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Model;
+
+use Magento\Framework\App\CacheInterface;
+
+class RefundLock
+{
+    private const CACHE_PREFIX = 'aplazo_refund_lock_';
+
+    public function __construct(private CacheInterface $cache)
+    {
+    }
+
+    public function acquire(string $key, int $ttlSeconds = 300): bool
+    {
+        $cacheKey = $this->toCacheKey($key);
+        if ($this->cache->load($cacheKey)) {
+            return false;
+        }
+
+        // Best-effort lock. Cache backends are shared (Redis/Valkey) in most Magento setups.
+        return (bool)$this->cache->save('1', $cacheKey, [], $ttlSeconds);
+    }
+
+    public function release(string $key): void
+    {
+        $this->cache->remove($this->toCacheKey($key));
+    }
+
+    private function toCacheKey(string $key): string
+    {
+        // Avoid cache key length limits and illegal characters.
+        return self::CACHE_PREFIX . sha1($key);
+    }
+}
+

--- a/Model/RefundQueueManagement.php
+++ b/Model/RefundQueueManagement.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Model;
+
+use Aplazo\AplazoPayment\Api\RefundQueueManagementInterface;
+use Aplazo\AplazoPayment\Api\RefundRequestRepositoryInterface;
+use Aplazo\AplazoPayment\Helper\Data;
+use Aplazo\AplazoPayment\Model\ResourceModel\RefundRequest\CollectionFactory;
+use Aplazo\AplazoPayment\Service\ApiService;
+use Magento\Sales\Api\OrderRepositoryInterface;
+
+class RefundQueueManagement implements RefundQueueManagementInterface
+{
+    private const MAX_RETRIES = 5;
+    public function __construct(
+        private CollectionFactory $collectionFactory,
+        private RefundRequestRepositoryInterface $refundRequestRepository,
+        private ApiService $apiService,
+        private RefundLock $refundLock,
+        private Data $data,
+        private OrderRepositoryInterface $orderRepository
+    ) {
+    }
+
+    public function process(int $batchSize = 20): int
+    {
+        $nowUtc = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('status', ['eq' => 'pending']);
+        $collection->getSelect()->where('(next_attempt_at IS NULL OR next_attempt_at <= ?)', $nowUtc);
+        $collection->setOrder('created_at', 'ASC');
+        $collection->setPageSize(max(1, (int)$batchSize));
+        $collection->setCurPage(1);
+
+        $attempted = 0;
+        foreach ($collection as $request) {
+            $attempted++;
+            $this->processOne($request);
+        }
+
+        return $attempted;
+    }
+
+    private function processOne(RefundRequest $request): void
+    {
+        // Lock first (prevents parallel processing in multi-cron environments).
+        $lockKey = $request->getType() . '|' . $request->getIdempotencyKey();
+        if (!$this->refundLock->acquire($lockKey, 300)) {
+            $this->scheduleRetry($request, 'Lock already acquired; skipping', 1);
+            return;
+        }
+
+        try {
+            $request->setStatus(RefundRequest::STATUS_PROCESSING);
+            $this->refundRequestRepository->save($request);
+
+            $payload = json_decode($request->getPayloadJson(), true) ?: [];
+            $response = $this->apiService->createRefund($payload, $request->getIdempotencyKey());
+            $this->handleRefundResponse($request, $response);
+        } catch (\Throwable $e) {
+            $this->scheduleRetry($request, $e->getMessage(), $this->computeBackoffMinutes($request->getRetries()));
+        } finally {
+            $this->refundLock->release($lockKey);
+        }
+    }
+
+    private function handleRefundResponse(RefundRequest $request, array $response): void
+    {
+        $refundId = $response['refundId'] ?? null;
+        $refundStatus = $response['refundStatus'] ?? null;
+
+        if (!$refundId) {
+            $this->scheduleRetry($request, 'Bad service response.', 1, $response);
+            return;
+        }
+
+        if ($refundStatus === 'REJECTED') {
+            $request->setStatus(RefundRequest::STATUS_FAILED);
+            $request->setLastError('Refund rejected by Aplazo');
+            $request->setAplazoRefundId((string)$refundId);
+            $request->setAplazoRefundStatus((string)$refundStatus);
+            $request->setResponseJson(json_encode($response, JSON_UNESCAPED_SLASHES));
+            $this->refundRequestRepository->save($request);
+
+            $this->appendOrderHistory($request, __('Aplazo refund rejected. RefundId: %1', (string)$refundId));
+            return;
+        }
+
+        if ($refundStatus !== 'REQUESTED') {
+            $this->scheduleRetry($request, 'Unexpected refundStatus: ' . (string)$refundStatus, 5, $response);
+            return;
+        }
+
+        $request->setStatus(RefundRequest::STATUS_SUCCESS);
+        $request->setAplazoRefundId((string)$refundId);
+        $request->setAplazoRefundStatus((string)$refundStatus);
+        $request->setResponseJson(json_encode($response, JSON_UNESCAPED_SLASHES));
+        $this->refundRequestRepository->save($request);
+
+        if ($request->getType() === 'rma') {
+            $this->applyRmaQtyRefunded($request);
+        }
+
+        $this->appendOrderHistory($request, __('Aplazo refund processed successfully. RefundId: %1', (string)$refundId));
+    }
+
+    private function scheduleRetry(
+        RefundRequest $request,
+        string $error,
+        int $backoffMinutes,
+        array $response = []
+    ): void {
+        if ($request->getRetries() >= self::MAX_RETRIES) {
+            $request->setStatus(RefundRequest::STATUS_FAILED);
+            $request->setLastError($error);
+            $request->setResponseJson($response ? json_encode($response, JSON_UNESCAPED_SLASHES) : null);
+            $this->refundRequestRepository->save($request);
+            $this->appendOrderHistory(
+                $request,
+                __('Aplazo refund failed permanently after %1 retries. %2', (string)self::MAX_RETRIES, $error)
+            );
+            return;
+        }
+
+        $nextAttemptAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+            ->modify('+' . max(1, (int)$backoffMinutes) . ' minutes')
+            ->format('Y-m-d H:i:s');
+
+        $request->setStatus(RefundRequest::STATUS_PENDING);
+        $request->setRetries($request->getRetries() + 1);
+        $request->setLastError($error);
+        $request->setNextAttemptAt($nextAttemptAt);
+        $request->setResponseJson($response ? json_encode($response, JSON_UNESCAPED_SLASHES) : null);
+        $this->refundRequestRepository->save($request);
+
+        $this->data->log('Refund queue retry scheduled for entity_id=' . $request->getId() . " in {$backoffMinutes}m. Error: $error");
+    }
+
+    private function computeBackoffMinutes(int $retries): int
+    {
+        return match (true) {
+            $retries <= 0 => 1,
+            $retries === 1 => 5,
+            $retries === 2 => 15,
+            $retries === 3 => 60,
+            default => 180,
+        };
+    }
+
+    private function appendOrderHistory(RefundRequest $request, \Magento\Framework\Phrase $message): void
+    {
+        $orderId = $request->getOrderId();
+        if (!$orderId) {
+            return;
+        }
+
+        try {
+            $order = $this->orderRepository->get($orderId);
+            $order->addCommentToStatusHistory((string)$message);
+            $this->orderRepository->save($order);
+        } catch (\Throwable $e) {
+            $this->data->log('Unable to append order history: ' . $e->getMessage());
+        }
+    }
+
+    private function applyRmaQtyRefunded(RefundRequest $request): void
+    {
+        if (!class_exists(\Magento\Rma\Model\ItemFactory::class)) {
+            return;
+        }
+
+        $rmaItemId = $request->getRmaItemId();
+        if (!$rmaItemId) {
+            return;
+        }
+
+        $qty = $request->getQty();
+        if (!$qty || $qty <= 0) {
+            return;
+        }
+        $qtyInt = (int)round($qty);
+
+        /** @var \Magento\Rma\Model\ItemFactory $itemFactory */
+        $itemFactory = \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Rma\Model\ItemFactory::class);
+        /** @var \Magento\Rma\Model\Item $itemModel */
+        $itemModel = $itemFactory->create()->load($rmaItemId);
+        if (!$itemModel->getId()) {
+            return;
+        }
+
+        $current = (int)$itemModel->getData('qty_aplazo_refunded');
+        $itemModel->setData('qty_aplazo_refunded', $current + $qtyInt);
+        $itemModel->save();
+    }
+}
+

--- a/Model/RefundRequest.php
+++ b/Model/RefundRequest.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Model;
+
+use Aplazo\AplazoPayment\Api\Data\RefundRequestInterface;
+use Magento\Framework\Model\AbstractExtensibleModel;
+
+class RefundRequest extends AbstractExtensibleModel implements RefundRequestInterface
+{
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_PROCESSING = 'processing';
+    public const STATUS_SUCCESS = 'success';
+    public const STATUS_FAILED = 'failed';
+    public const STATUS_CANCELLED = 'cancelled';
+
+    protected function _construct()
+    {
+        $this->_init(\Aplazo\AplazoPayment\Model\ResourceModel\RefundRequest::class);
+    }
+
+    public function getId(): ?int
+    {
+        $value = parent::getId();
+        return $value === null ? null : (int)$value;
+    }
+
+    public function setId($id): RefundRequestInterface
+    {
+        parent::setId($id);
+        return $this;
+    }
+
+    public function getType(): string
+    {
+        return (string)$this->getData(self::TYPE);
+    }
+
+    public function setType(string $type): RefundRequestInterface
+    {
+        return $this->setData(self::TYPE, $type);
+    }
+
+    public function getStatus(): string
+    {
+        return (string)$this->getData(self::STATUS);
+    }
+
+    public function setStatus(string $status): RefundRequestInterface
+    {
+        return $this->setData(self::STATUS, $status);
+    }
+
+    public function getOrderIncrementId(): string
+    {
+        return (string)$this->getData(self::ORDER_INCREMENT_ID);
+    }
+
+    public function setOrderIncrementId(string $orderIncrementId): RefundRequestInterface
+    {
+        return $this->setData(self::ORDER_INCREMENT_ID, $orderIncrementId);
+    }
+
+    public function getOrderId(): ?int
+    {
+        $value = $this->getData(self::ORDER_ID);
+        return $value === null ? null : (int)$value;
+    }
+
+    public function setOrderId(?int $orderId): RefundRequestInterface
+    {
+        return $this->setData(self::ORDER_ID, $orderId);
+    }
+
+    public function getCreditmemoId(): ?int
+    {
+        $value = $this->getData(self::CREDITMEMO_ID);
+        return $value === null ? null : (int)$value;
+    }
+
+    public function setCreditmemoId(?int $creditmemoId): RefundRequestInterface
+    {
+        return $this->setData(self::CREDITMEMO_ID, $creditmemoId);
+    }
+
+    public function getRmaEntityId(): ?int
+    {
+        $value = $this->getData(self::RMA_ENTITY_ID);
+        return $value === null ? null : (int)$value;
+    }
+
+    public function setRmaEntityId(?int $rmaEntityId): RefundRequestInterface
+    {
+        return $this->setData(self::RMA_ENTITY_ID, $rmaEntityId);
+    }
+
+    public function getRmaItemId(): ?int
+    {
+        $value = $this->getData(self::RMA_ITEM_ID);
+        return $value === null ? null : (int)$value;
+    }
+
+    public function setRmaItemId(?int $rmaItemId): RefundRequestInterface
+    {
+        return $this->setData(self::RMA_ITEM_ID, $rmaItemId);
+    }
+
+    public function getOrderItemId(): ?int
+    {
+        $value = $this->getData(self::ORDER_ITEM_ID);
+        return $value === null ? null : (int)$value;
+    }
+
+    public function setOrderItemId(?int $orderItemId): RefundRequestInterface
+    {
+        return $this->setData(self::ORDER_ITEM_ID, $orderItemId);
+    }
+
+    public function getQty(): ?float
+    {
+        $value = $this->getData(self::QTY);
+        return $value === null ? null : (float)$value;
+    }
+
+    public function setQty(?float $qty): RefundRequestInterface
+    {
+        return $this->setData(self::QTY, $qty);
+    }
+
+    public function getAmountCents(): int
+    {
+        return (int)$this->getData(self::AMOUNT_CENTS);
+    }
+
+    public function setAmountCents(int $amountCents): RefundRequestInterface
+    {
+        return $this->setData(self::AMOUNT_CENTS, $amountCents);
+    }
+
+    public function getCurrency(): ?string
+    {
+        $value = $this->getData(self::CURRENCY);
+        return $value === null ? null : (string)$value;
+    }
+
+    public function setCurrency(?string $currency): RefundRequestInterface
+    {
+        return $this->setData(self::CURRENCY, $currency);
+    }
+
+    public function getReason(): ?string
+    {
+        $value = $this->getData(self::REASON);
+        return $value === null ? null : (string)$value;
+    }
+
+    public function setReason(?string $reason): RefundRequestInterface
+    {
+        return $this->setData(self::REASON, $reason);
+    }
+
+    public function getReasonHash(): ?string
+    {
+        $value = $this->getData(self::REASON_HASH);
+        return $value === null ? null : (string)$value;
+    }
+
+    public function setReasonHash(?string $reasonHash): RefundRequestInterface
+    {
+        return $this->setData(self::REASON_HASH, $reasonHash);
+    }
+
+    public function getItemsHash(): ?string
+    {
+        $value = $this->getData(self::ITEMS_HASH);
+        return $value === null ? null : (string)$value;
+    }
+
+    public function setItemsHash(?string $itemsHash): RefundRequestInterface
+    {
+        return $this->setData(self::ITEMS_HASH, $itemsHash);
+    }
+
+    public function getIdempotencyKey(): string
+    {
+        return (string)$this->getData(self::IDEMPOTENCY_KEY);
+    }
+
+    public function setIdempotencyKey(string $idempotencyKey): RefundRequestInterface
+    {
+        return $this->setData(self::IDEMPOTENCY_KEY, $idempotencyKey);
+    }
+
+    public function getPayloadJson(): string
+    {
+        return (string)$this->getData(self::PAYLOAD_JSON);
+    }
+
+    public function setPayloadJson(string $payloadJson): RefundRequestInterface
+    {
+        return $this->setData(self::PAYLOAD_JSON, $payloadJson);
+    }
+
+    public function getResponseJson(): ?string
+    {
+        $value = $this->getData(self::RESPONSE_JSON);
+        return $value === null ? null : (string)$value;
+    }
+
+    public function setResponseJson(?string $responseJson): RefundRequestInterface
+    {
+        return $this->setData(self::RESPONSE_JSON, $responseJson);
+    }
+
+    public function getAplazoRefundId(): ?string
+    {
+        $value = $this->getData(self::APLAZO_REFUND_ID);
+        return $value === null ? null : (string)$value;
+    }
+
+    public function setAplazoRefundId(?string $aplazoRefundId): RefundRequestInterface
+    {
+        return $this->setData(self::APLAZO_REFUND_ID, $aplazoRefundId);
+    }
+
+    public function getAplazoRefundStatus(): ?string
+    {
+        $value = $this->getData(self::APLAZO_REFUND_STATUS);
+        return $value === null ? null : (string)$value;
+    }
+
+    public function setAplazoRefundStatus(?string $aplazoRefundStatus): RefundRequestInterface
+    {
+        return $this->setData(self::APLAZO_REFUND_STATUS, $aplazoRefundStatus);
+    }
+
+    public function getRetries(): int
+    {
+        $value = $this->getData(self::RETRIES);
+        return $value === null ? 0 : (int)$value;
+    }
+
+    public function setRetries(int $retries): RefundRequestInterface
+    {
+        return $this->setData(self::RETRIES, $retries);
+    }
+
+    public function getLastError(): ?string
+    {
+        $value = $this->getData(self::LAST_ERROR);
+        return $value === null ? null : (string)$value;
+    }
+
+    public function setLastError(?string $lastError): RefundRequestInterface
+    {
+        return $this->setData(self::LAST_ERROR, $lastError);
+    }
+
+    public function getNextAttemptAt(): ?string
+    {
+        $value = $this->getData(self::NEXT_ATTEMPT_AT);
+        return $value === null ? null : (string)$value;
+    }
+
+    public function setNextAttemptAt(?string $nextAttemptAt): RefundRequestInterface
+    {
+        return $this->setData(self::NEXT_ATTEMPT_AT, $nextAttemptAt);
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        $value = $this->getData(self::CREATED_AT);
+        return $value === null ? null : (string)$value;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        $value = $this->getData(self::UPDATED_AT);
+        return $value === null ? null : (string)$value;
+    }
+}
+

--- a/Model/RefundRequestRepository.php
+++ b/Model/RefundRequestRepository.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Model;
+
+use Aplazo\AplazoPayment\Api\Data\RefundRequestInterface;
+use Aplazo\AplazoPayment\Api\Data\RefundRequestSearchResultsInterface;
+use Aplazo\AplazoPayment\Api\Data\RefundRequestSearchResultsInterfaceFactory;
+use Aplazo\AplazoPayment\Api\RefundRequestRepositoryInterface;
+use Aplazo\AplazoPayment\Model\ResourceModel\RefundRequest as RefundRequestResource;
+use Aplazo\AplazoPayment\Model\ResourceModel\RefundRequest\CollectionFactory as RefundRequestCollectionFactory;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Model\AbstractModel;
+
+class RefundRequestRepository implements RefundRequestRepositoryInterface
+{
+    public function __construct(
+        private RefundRequestResource $resource,
+        private RefundRequestFactory $refundRequestFactory,
+        private RefundRequestCollectionFactory $collectionFactory,
+        private RefundRequestSearchResultsInterfaceFactory $searchResultsFactory,
+        private CollectionProcessorInterface $collectionProcessor
+    ) {
+    }
+
+    public function save(RefundRequestInterface $refundRequest): RefundRequestInterface
+    {
+        if (!$refundRequest instanceof AbstractModel) {
+            throw new CouldNotSaveException(__('Invalid refund request model instance.'));
+        }
+        /** @var AbstractModel $refundRequest */
+
+        try {
+            $this->resource->save($refundRequest);
+        } catch (AlreadyExistsException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            throw new CouldNotSaveException(__('Could not save refund request: %1', $e->getMessage()), $e);
+        }
+
+        return $refundRequest;
+    }
+
+    public function getById(int $entityId): RefundRequestInterface
+    {
+        $model = $this->refundRequestFactory->create();
+        $this->resource->load($model, $entityId);
+        if (!$model->getId()) {
+            throw new NoSuchEntityException(__('Refund request with id "%1" does not exist.', $entityId));
+        }
+        return $model;
+    }
+
+    public function getList(SearchCriteriaInterface $searchCriteria): RefundRequestSearchResultsInterface
+    {
+        $collection = $this->collectionFactory->create();
+        $this->collectionProcessor->process($searchCriteria, $collection);
+
+        $searchResults = $this->searchResultsFactory->create();
+        $searchResults->setSearchCriteria($searchCriteria);
+        $searchResults->setTotalCount((int)$collection->getSize());
+        $searchResults->setItems($collection->getItems());
+
+        return $searchResults;
+    }
+
+    public function delete(RefundRequestInterface $refundRequest): bool
+    {
+        try {
+            $this->resource->delete($refundRequest);
+        } catch (\Throwable $e) {
+            throw new CouldNotDeleteException(__('Could not delete refund request: %1', $e->getMessage()), $e);
+        }
+        return true;
+    }
+
+    public function deleteById(int $entityId): bool
+    {
+        return $this->delete($this->getById($entityId));
+    }
+}
+

--- a/Model/RefundRequestSearchResults.php
+++ b/Model/RefundRequestSearchResults.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Model;
+
+use Aplazo\AplazoPayment\Api\Data\RefundRequestSearchResultsInterface;
+use Magento\Framework\Api\SearchResults;
+
+class RefundRequestSearchResults extends SearchResults implements RefundRequestSearchResultsInterface
+{
+}
+

--- a/Model/ResourceModel/RefundRequest.php
+++ b/Model/ResourceModel/RefundRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class RefundRequest extends AbstractDb
+{
+    protected function _construct()
+    {
+        $this->_init('aplazo_refund_request', 'entity_id');
+    }
+}
+

--- a/Model/ResourceModel/RefundRequest/Collection.php
+++ b/Model/ResourceModel/RefundRequest/Collection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Model\ResourceModel\RefundRequest;
+
+use Aplazo\AplazoPayment\Model\RefundRequest as Model;
+use Aplazo\AplazoPayment\Model\ResourceModel\RefundRequest as ResourceModel;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+
+class Collection extends AbstractCollection
+{
+    protected function _construct()
+    {
+        $this->_init(Model::class, ResourceModel::class);
+    }
+}
+

--- a/Model/ResourceModel/RefundRequest/Grid/Collection.php
+++ b/Model/ResourceModel/RefundRequest/Grid/Collection.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Model\ResourceModel\RefundRequest\Grid;
+
+use Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult;
+
+class Collection extends SearchResult
+{
+    protected function _initSelect()
+    {
+        $this->addFilterToMap('entity_id', 'main_table.entity_id');
+        return parent::_initSelect();
+    }
+}
+

--- a/Observer/RefundObserverAfterSave.php
+++ b/Observer/RefundObserverAfterSave.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Observer;
+
+use Aplazo\AplazoPayment\Helper\Data;
+use Aplazo\AplazoPayment\Model\RefundRequest;
+use Aplazo\AplazoPayment\Model\RefundRequestFactory;
+use Aplazo\AplazoPayment\Model\Ui\ConfigProvider;
+use Aplazo\AplazoPayment\Api\RefundRequestRepositoryInterface;
+use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order\Creditmemo;
+
+class RefundObserverAfterSave implements ObserverInterface
+{
+    private const TYPE_CREDITMEMO = 'creditmemo';
+
+    public function __construct(
+        private RefundRequestFactory $refundRequestFactory,
+        private RefundRequestRepositoryInterface $refundRequestRepository,
+        private OrderRepositoryInterface $orderRepository,
+        private ManagerInterface $messageManager,
+        private Data $data
+    ) {
+    }
+
+    public function execute(Observer $observer)
+    {
+        /** @var Creditmemo|null $creditMemo */
+        $creditMemo = $observer->getData('creditmemo');
+        if (!$creditMemo) {
+            return;
+        }
+
+        $order = $creditMemo->getOrder();
+        if (!$order || !$order->getEntityId()) {
+            return;
+        }
+
+        $payment = $order->getPayment();
+        $paymentMethod = $payment ? (string)$payment->getMethod() : null;
+        if ($paymentMethod !== ConfigProvider::CODE) {
+            return;
+        }
+
+        if (!$this->data->getRefund()) {
+            $this->messageManager->addErrorMessage(
+                __('The refund will be made offline since the Aplazo refund option is not activated in the configuration')
+            );
+            return;
+        }
+
+        $amount = (float)$creditMemo->getGrandTotal();
+        $amountCents = (int)round($amount * 100);
+        $currency = (string)($order->getOrderCurrencyCode() ?: $order->getBaseCurrencyCode() ?: '');
+
+        $reason = '';
+        foreach ($creditMemo->getComments() as $index => $comment) {
+            $reason .= $index . '. ' . $comment->getComment() . '.  ';
+        }
+        $reasonHash = hash('sha256', (string)$reason);
+
+        $itemsFingerprint = $this->buildCreditmemoItemsFingerprint($creditMemo);
+        $idempotencyKey = hash('sha256', json_encode([
+            'type' => self::TYPE_CREDITMEMO,
+            'orderIncrementId' => (string)$order->getIncrementId(),
+            'amountCents' => $amountCents,
+            'currency' => $currency,
+            'items' => $itemsFingerprint,
+            'reasonHash' => $reasonHash,
+        ], JSON_UNESCAPED_SLASHES));
+
+        $payload = [
+            'cartId' => (string)$order->getIncrementId(),
+            'totalAmount' => $amount,
+            'reason' => $reason,
+        ];
+
+        try {
+            /** @var RefundRequest $refundRequest */
+            $refundRequest = $this->refundRequestFactory->create();
+            $refundRequest->setType(self::TYPE_CREDITMEMO);
+            $refundRequest->setStatus(RefundRequest::STATUS_PENDING);
+            $refundRequest->setOrderIncrementId((string)$order->getIncrementId());
+            $refundRequest->setOrderId((int)$order->getEntityId());
+            $refundRequest->setCreditmemoId((int)$creditMemo->getEntityId());
+            $refundRequest->setAmountCents($amountCents);
+            $refundRequest->setCurrency($currency);
+            $refundRequest->setReason($reason);
+            $refundRequest->setReasonHash($reasonHash);
+            $refundRequest->setItemsHash(hash('sha256', json_encode($itemsFingerprint, JSON_UNESCAPED_SLASHES)));
+            $refundRequest->setIdempotencyKey($idempotencyKey);
+            $refundRequest->setPayloadJson(json_encode($payload, JSON_UNESCAPED_SLASHES));
+            $refundRequest->setRetries(0);
+            $refundRequest->setNextAttemptAt(null);
+
+            $this->refundRequestRepository->save($refundRequest);
+
+            $message = __('Credit memo created. Aplazo refund has been queued and will be processed shortly.');
+            $this->messageManager->addSuccessMessage($message);
+
+            $order->addCommentToStatusHistory((string)$message . ' ' . __('Idempotency key: %1', $idempotencyKey));
+            $this->orderRepository->save($order);
+        } catch (AlreadyExistsException $e) {
+            // Dedupe hit: the refund request already exists.
+            $message = __('Aplazo refund is already queued for this credit memo. Please wait and check the order history.');
+            $this->messageManager->addWarningMessage($message);
+        } catch (\Throwable $e) {
+            // Never block the credit memo save for queue failures; just inform the user.
+            $this->messageManager->addErrorMessage(
+                __('Credit memo created, but the Aplazo refund could not be queued. Please check logs. %1', $e->getMessage())
+            );
+        }
+    }
+
+    /**
+     * @return array<int, array{orderItemId:int,qty:float,rowTotalCents:int}>
+     */
+    private function buildCreditmemoItemsFingerprint(Creditmemo $creditMemo): array
+    {
+        $items = [];
+        foreach ($creditMemo->getAllItems() as $item) {
+            $qty = (float)$item->getQty();
+            if ($qty <= 0.0) {
+                continue;
+            }
+
+            $items[] = [
+                'orderItemId' => (int)$item->getOrderItemId(),
+                'qty' => $qty,
+                'rowTotalCents' => (int)round(((float)$item->getRowTotal()) * 100),
+            ];
+        }
+
+        usort($items, static fn(array $a, array $b) => $a['orderItemId'] <=> $b['orderItemId']);
+        return $items;
+    }
+}
+

--- a/Observer/RmaObserverAfterSave.php
+++ b/Observer/RmaObserverAfterSave.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Aplazo\AplazoPayment\Observer;
+
+use Aplazo\AplazoPayment\Helper\Data;
+use Aplazo\AplazoPayment\Api\RefundRequestRepositoryInterface;
+use Aplazo\AplazoPayment\Model\RefundRequest;
+use Aplazo\AplazoPayment\Model\RefundRequestFactory;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Sales\Api\OrderItemRepositoryInterface;
+
+class RmaObserverAfterSave implements ObserverInterface
+{
+    private const TYPE_RMA = 'rma';
+    private const RMA_REFUND_RESOLUTION = 5;
+
+    public function __construct(
+        private RefundRequestFactory $refundRequestFactory,
+        private RefundRequestRepositoryInterface $refundRequestRepository,
+        private OrderItemRepositoryInterface $orderItemRepository,
+        private ManagerInterface $messageManager,
+        private Data $data
+    ) {
+    }
+
+    public function execute(Observer $observer)
+    {
+        if (
+            !$this->data->getRmaRefund()
+            || !class_exists(\Magento\Rma\Model\ItemFactory::class)
+            || !class_exists(\Magento\Rma\Model\Rma\Source\Status::class)
+        ) {
+            return;
+        }
+
+        /** @var \Magento\Rma\Model\Rma|null $rma */
+        $rma = $observer->getData('rma');
+        if (!$rma) {
+            return;
+        }
+
+        $orderIncrementId = (string)$rma->getOrderIncrementId();
+        $rmaEntityId = (int)$rma->getEntityId();
+
+        /** @var \Magento\Rma\Model\ItemFactory $itemFactory */
+        $itemFactory = \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Rma\Model\ItemFactory::class);
+
+        $currency = ''; // RMA does not always carry currency; keep optional.
+
+        foreach ((array)$rma->getItems() as $item) {
+            if (
+                (int)$item->getResolution() !== self::RMA_REFUND_RESOLUTION
+                || (int)$item->getStatus() !== (int)\Magento\Rma\Model\Rma\Source\Status::STATE_APPROVED
+            ) {
+                continue;
+            }
+
+            /** @var \Magento\Rma\Model\Item $itemModel */
+            $itemModel = $itemFactory->create()->load((int)$item->getEntityId());
+
+            $qtyApproved = (float)$item->getQtyApproved();
+            $qtyAplazoRefunded = (int)$itemModel->getData('qty_aplazo_refunded');
+            $qtyToSend = $qtyApproved - $qtyAplazoRefunded;
+
+            // Aplazo has already refunded all approved qty.
+            if ($qtyToSend <= 0) {
+                continue;
+            }
+
+            $orderItemId = (int)$item->getOrderItemId();
+            $orderItem = $this->orderItemRepository->get($orderItemId);
+
+            $amount = (float)$orderItem->getPrice() * $qtyToSend;
+            $amountCents = (int)round($amount * 100);
+
+            $reason = (string)$item->getReason();
+            $reasonHash = hash('sha256', $reason);
+
+            $itemsFingerprint = [
+                'rmaItemId' => (int)$item->getEntityId(),
+                'orderItemId' => $orderItemId,
+                'qtyToSend' => (float)$qtyToSend,
+                'unitPriceCents' => (int)round(((float)$orderItem->getPrice()) * 100),
+            ];
+
+            $idempotencyKey = hash('sha256', json_encode([
+                'type' => self::TYPE_RMA,
+                'orderIncrementId' => $orderIncrementId,
+                'rmaEntityId' => $rmaEntityId,
+                'item' => $itemsFingerprint,
+                'amountCents' => $amountCents,
+                'reasonHash' => $reasonHash,
+            ], JSON_UNESCAPED_SLASHES));
+
+            $payload = [
+                'cartId' => $orderIncrementId,
+                'totalAmount' => $amount,
+                'reason' => $reason,
+            ];
+
+            try {
+                /** @var RefundRequest $refundRequest */
+                $refundRequest = $this->refundRequestFactory->create();
+                $refundRequest->setType(self::TYPE_RMA);
+                $refundRequest->setStatus(RefundRequest::STATUS_PENDING);
+                $refundRequest->setOrderIncrementId($orderIncrementId);
+                $refundRequest->setOrderId(null);
+                $refundRequest->setCreditmemoId(null);
+                $refundRequest->setRmaEntityId($rmaEntityId);
+                $refundRequest->setRmaItemId((int)$item->getEntityId());
+                $refundRequest->setOrderItemId($orderItemId);
+                $refundRequest->setQty((float)$qtyToSend);
+                $refundRequest->setAmountCents($amountCents);
+                $refundRequest->setCurrency($currency);
+                $refundRequest->setReason($reason);
+                $refundRequest->setReasonHash($reasonHash);
+                $refundRequest->setItemsHash(hash('sha256', json_encode($itemsFingerprint, JSON_UNESCAPED_SLASHES)));
+                $refundRequest->setIdempotencyKey($idempotencyKey);
+                $refundRequest->setPayloadJson(json_encode($payload, JSON_UNESCAPED_SLASHES));
+                $refundRequest->setRetries(0);
+                $refundRequest->setNextAttemptAt(null);
+
+                $this->refundRequestRepository->save($refundRequest);
+            } catch (AlreadyExistsException $e) {
+                // Already queued.
+                continue;
+            } catch (\Throwable $e) {
+                // Do not block RMA save.
+                $this->messageManager->addErrorMessage(
+                    __('RMA saved, but the Aplazo refund could not be queued. Please check logs. %1', $e->getMessage())
+                );
+            }
+        }
+    }
+}
+

--- a/Service/ApiService.php
+++ b/Service/ApiService.php
@@ -13,6 +13,8 @@ class ApiService
     const TOKEN_CACHE_KEY = 'aplazo_api_token';
     const API_POST = 'POST';
     const LOAN_SUCCESS_STATUS = 'OUTSTANDING';
+    private const DEFAULT_CONNECT_TIMEOUT_SECONDS = 10;
+    private const DEFAULT_TIMEOUT_SECONDS = 90;
 
     /**
      * @var AplazoHelper
@@ -59,11 +61,14 @@ class ApiService
      * @return array
      * @throws LocalizedException
      */
-    public function createRefund($orderData)
+    public function createRefund($orderData, ?string $idempotencyKey = null)
     {
         $response = $this->requestService(
             $this->getRefundLoanUrl(),
-            json_encode($orderData)
+            json_encode($orderData),
+            self::API_POST,
+            false,
+            $idempotencyKey ? ['X-Idempotency-Key' => $idempotencyKey] : []
         );
 
         return $response;
@@ -182,9 +187,9 @@ class ApiService
         return $this->aplazoHelper->getServiceUrl() . "/api/pos/loan/$cartId";
     }
 
-    private function requestService($url, $body, $method = self::API_POST, $bearer = false)
+    private function requestService($url, $body, $method = self::API_POST, $bearer = false, array $extraHeaders = [])
     {
-        $response = $this->requestMagentoCurl($url, $body, $method, $bearer);
+        $response = $this->requestMagentoCurl($url, $body, $method, $bearer, $extraHeaders);
 
         if (!$response['success']) {
             $message = __('No response from request to ' . $url);
@@ -204,7 +209,7 @@ class ApiService
         return $response['data'];
     }
 
-    public function requestMagentoCurl($url, $body, $method, $bearer)
+    public function requestMagentoCurl($url, $body, $method, $bearer, array $extraHeaders = [])
     {
         $headers = [
             'merchant_id' => $this->aplazoHelper->getMerchantId(),
@@ -214,21 +219,28 @@ class ApiService
         if($bearer){
             $headers['Authorization'] = $bearer;
         }
+        if ($extraHeaders) {
+            $headers = array_merge($headers, $extraHeaders);
+        }
         try{
             $this->curl->setHeaders($headers);
+            $this->curl->setOption(CURLOPT_CONNECTTIMEOUT, self::DEFAULT_CONNECT_TIMEOUT_SECONDS);
+            $this->curl->setOption(CURLOPT_TIMEOUT, self::DEFAULT_TIMEOUT_SECONDS);
             if ($method === self::API_POST) {
                 $this->curl->post($url, $body);
             } else {
                 $this->curl->get($url);
             }
             $statusCode = $this->curl->getStatus();
-            switch ($statusCode) {
-                case 200 || 201 || 202:
-                    $response = $this->curl->getBody();
-                    return ['success' => true, 'data' => json_decode($response, true)];
-                default:
-                    return ['success' => false, 'message' => 'Unexpected HTTP status: ' . $statusCode];
+            $responseBody = $this->curl->getBody();
+            if (in_array((int)$statusCode, [200, 201, 202], true)) {
+                return ['success' => true, 'data' => json_decode($responseBody, true)];
             }
+
+            return [
+                'success' => false,
+                'message' => 'Unexpected HTTP status: ' . $statusCode . ' body: ' . $responseBody
+            ];
         }catch (\Exception $e) {
             $this->aplazoHelper->log('HTTP Request Error: ' . $e->getMessage());
             return ['success' => false, 'message' => 'HTTP Request Exception: ' . $e->getMessage()];

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Sales::sales">
+                    <resource id="Magento_Sales::sales_operation">
+                        <resource id="Magento_Sales::sales_order">
+                            <resource id="Magento_Sales::actions">
+                                <resource id="Magento_Sales::creditmemo">
+                                    <resource id="Aplazo_AplazoPayment::aplazo_refund_queue" title="Aplazo refund queue" sortOrder="90"/>
+                                </resource>
+                            </resource>
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>
+

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
+    <menu>
+        <add id="Aplazo_AplazoPayment::aplazo_refund_queue"
+             title="Aplazo refunds"
+             module="Aplazo_AplazoPayment"
+             sortOrder="90"
+             parent="Magento_Sales::sales"
+             action="aplazo/refundrequest/index"
+             resource="Aplazo_AplazoPayment::aplazo_refund_queue"/>
+    </menu>
+</config>
+

--- a/etc/adminhtml/routes.xml
+++ b/etc/adminhtml/routes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="aplazo" frontName="aplazo">
+            <module name="Aplazo_AplazoPayment" before="Magento_Backend"/>
+        </route>
+    </router>
+</config>
+

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -4,5 +4,8 @@
         <job name="aplazo_aplazopayment_cancel_orders" instance="Aplazo\AplazoPayment\Cron\CancelOrders" method="execute">
             <schedule>*/15 * * * *</schedule>
         </job>
+        <job name="aplazo_aplazopayment_process_refund_queue" instance="Aplazo\AplazoPayment\Cron\ProcessRefundQueue" method="execute">
+            <schedule>*/5 * * * *</schedule>
+        </job>
     </group>
 </config>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -2,6 +2,57 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
     <table name="sales_order" resource="default" engine="innodb">
-        <column xsi:type="varchar" name="aplazo_checkout_url" comment="Aplazo Checkout URL"/>
+        <column xsi:type="varchar" name="aplazo_checkout_url" length="255" nullable="true" comment="Aplazo Checkout URL"/>
+    </table>
+
+    <table name="aplazo_refund_request" resource="default" engine="innodb" comment="Aplazo refund request queue">
+        <column xsi:type="int" name="entity_id" unsigned="true" nullable="false" identity="true" comment="Entity ID"/>
+        <column xsi:type="varchar" name="type" length="32" nullable="false" comment="Request type"/>
+        <column xsi:type="varchar" name="status" length="16" nullable="false" default="pending" comment="Request status"/>
+
+        <column xsi:type="varchar" name="order_increment_id" length="32" nullable="false" comment="Order increment id"/>
+        <column xsi:type="int" name="order_id" unsigned="true" nullable="true" comment="Order entity id"/>
+
+        <column xsi:type="int" name="creditmemo_id" unsigned="true" nullable="true" comment="Creditmemo entity id"/>
+
+        <column xsi:type="int" name="rma_entity_id" unsigned="true" nullable="true" comment="RMA entity id"/>
+        <column xsi:type="int" name="rma_item_id" unsigned="true" nullable="true" comment="RMA item entity id"/>
+        <column xsi:type="int" name="order_item_id" unsigned="true" nullable="true" comment="Order item entity id"/>
+        <column xsi:type="decimal" name="qty" precision="12" scale="4" nullable="true" comment="Qty to refund"/>
+
+        <column xsi:type="int" name="amount_cents" nullable="false" comment="Refund amount (cents)"/>
+        <column xsi:type="varchar" name="currency" length="8" nullable="true" comment="Currency"/>
+
+        <column xsi:type="text" name="reason" nullable="true" comment="Refund reason"/>
+        <column xsi:type="varchar" name="reason_hash" length="64" nullable="true" comment="Reason hash"/>
+        <column xsi:type="varchar" name="items_hash" length="64" nullable="true" comment="Items hash"/>
+        <column xsi:type="varchar" name="idempotency_key" length="64" nullable="false" comment="Idempotency key"/>
+
+        <column xsi:type="text" name="payload_json" nullable="false" comment="Refund request payload JSON"/>
+        <column xsi:type="text" name="response_json" nullable="true" comment="Aplazo response JSON"/>
+
+        <column xsi:type="varchar" name="aplazo_refund_id" length="64" nullable="true" comment="Aplazo refund id"/>
+        <column xsi:type="varchar" name="aplazo_refund_status" length="32" nullable="true" comment="Aplazo refund status"/>
+
+        <column xsi:type="int" name="retries" nullable="false" default="0" comment="Retry count"/>
+        <column xsi:type="text" name="last_error" nullable="true" comment="Last error"/>
+        <column xsi:type="timestamp" name="next_attempt_at" nullable="true" default="NULL" comment="Next attempt at"/>
+
+        <column xsi:type="timestamp" name="created_at" nullable="false" default="CURRENT_TIMESTAMP" comment="Created at"/>
+        <column xsi:type="timestamp" name="updated_at" nullable="false" default="CURRENT_TIMESTAMP" on_update="true" comment="Updated at"/>
+
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="entity_id"/>
+        </constraint>
+
+        <constraint xsi:type="unique" referenceId="APLAZO_REFUND_REQUEST_TYPE_IDEMPOTENCY_KEY_UNQ">
+            <column name="type"/>
+            <column name="idempotency_key"/>
+        </constraint>
+
+        <index referenceId="APLAZO_REFUND_REQUEST_STATUS_NEXT_ATTEMPT_IDX" indexType="btree">
+            <column name="status"/>
+            <column name="next_attempt_at"/>
+        </index>
     </table>
 </schema>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -52,6 +52,11 @@
     <preference for="Aplazo\AplazoPayment\Api\CheckoutNotPaidManagementInterface" type="Aplazo\AplazoPayment\Model\CheckoutNotPaidManagement"/>
     <preference for="Aplazo\AplazoPayment\Api\CheckoutNotPaidManagementResponseInterface" type="Aplazo\AplazoPayment\Model\CheckoutNotPaidManagementResponse"/>
 
+    <preference for="Aplazo\AplazoPayment\Api\Data\RefundRequestInterface" type="Aplazo\AplazoPayment\Model\RefundRequest"/>
+    <preference for="Aplazo\AplazoPayment\Api\Data\RefundRequestSearchResultsInterface" type="Aplazo\AplazoPayment\Model\RefundRequestSearchResults"/>
+    <preference for="Aplazo\AplazoPayment\Api\RefundRequestRepositoryInterface" type="Aplazo\AplazoPayment\Model\RefundRequestRepository"/>
+    <preference for="Aplazo\AplazoPayment\Api\RefundQueueManagementInterface" type="Aplazo\AplazoPayment\Model\RefundQueueManagement"/>
+
     <virtualType name="AplazoGatewayCustomLogger" type="Magento\Framework\Logger\Monolog">
         <arguments>
             <argument name="handlers" xsi:type="array">
@@ -75,5 +80,29 @@
     </type>
     <type name="Magento\Quote\Observer\SubmitObserver">
         <plugin name="aplazo_payment_new_order_email" type="Aplazo\AplazoPayment\Plugin\Order\NewOrderEmail" />
+    </type>
+
+    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
+        <arguments>
+            <argument name="collections" xsi:type="array">
+                <item name="aplazo_refund_request_listing_data_source" xsi:type="string">Aplazo\AplazoPayment\Model\ResourceModel\RefundRequest\Grid\Collection</item>
+            </argument>
+        </arguments>
+    </type>
+
+    <type name="Aplazo\AplazoPayment\Model\ResourceModel\RefundRequest\Grid\Collection">
+        <arguments>
+            <argument name="mainTable" xsi:type="string">aplazo_refund_request</argument>
+            <argument name="resourceModel" xsi:type="string">Aplazo\AplazoPayment\Model\ResourceModel\RefundRequest</argument>
+        </arguments>
+    </type>
+
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="aplazo_refund_process" xsi:type="object">Aplazo\AplazoPayment\Console\Command\ProcessRefundQueueCommand</item>
+                <item name="aplazo_orders_cancel" xsi:type="object">Aplazo\AplazoPayment\Console\Command\CancelOrdersCommand</item>
+            </argument>
+        </arguments>
     </type>
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -6,11 +6,11 @@
     <event name="sales_order_place_after">
         <observer name="aplazo_sales_order_place_after_create_loan" instance="Aplazo\AplazoPayment\Observer\SalesOrderPlaceAfterCreateLoan" />
     </event>
-    <event name="sales_order_creditmemo_save_before">
-        <observer name="aplazo_creditmemo_before_save_observer" instance="Aplazo\AplazoPayment\Observer\RefundObserverBeforeSave"/>
+    <event name="sales_order_creditmemo_save_after">
+        <observer name="aplazo_creditmemo_after_save_enqueue_refund" instance="Aplazo\AplazoPayment\Observer\RefundObserverAfterSave"/>
     </event>
-    <event name="rma_save_before">
-        <observer name="aplazo_rma_before_save_observer" instance="Aplazo\AplazoPayment\Observer\RmaObserverBeforeSave"/>
+    <event name="rma_save_after">
+        <observer name="aplazo_rma_after_save_enqueue_refund" instance="Aplazo\AplazoPayment\Observer\RmaObserverAfterSave"/>
     </event>
     <event name="admin_system_config_changed_section_payment">
         <observer name="aplazo_check_healthy_site" instance="Aplazo\AplazoPayment\Observer\HealthySite"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -2,6 +2,9 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Aplazo_AplazoPayment" setup_version="4.0.7">
         <sequence>
+            <module name="Magento_Backend"/>
+            <module name="Magento_Ui"/>
+            <module name="Magento_Authorization"/>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>
             <module name="Magento_Checkout"/>

--- a/view/adminhtml/layout/aplazo_refundrequest_index.xml
+++ b/view/adminhtml/layout/aplazo_refundrequest_index.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="aplazo_refund_request_listing"/>
+        </referenceContainer>
+    </body>
+</page>
+

--- a/view/adminhtml/ui_component/aplazo_refund_request_listing.xml
+++ b/view/adminhtml/ui_component/aplazo_refund_request_listing.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">aplazo_refund_request_listing.aplazo_refund_request_listing_data_source</item>
+        </item>
+    </argument>
+
+    <settings>
+        <spinner>aplazo_refund_request_columns</spinner>
+        <deps>
+            <dep>aplazo_refund_request_listing.aplazo_refund_request_listing_data_source</dep>
+        </deps>
+    </settings>
+
+    <dataSource name="aplazo_refund_request_listing_data_source" component="Magento_Ui/js/grid/provider">
+        <settings>
+            <updateUrl path="mui/index/render"/>
+        </settings>
+        <aclResource>Aplazo_AplazoPayment::aplazo_refund_queue</aclResource>
+        <dataProvider class="Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider" name="aplazo_refund_request_listing_data_source">
+            <settings>
+                <requestFieldName>entity_id</requestFieldName>
+                <primaryFieldName>main_table.entity_id</primaryFieldName>
+            </settings>
+        </dataProvider>
+    </dataSource>
+
+    <listingToolbar name="listing_top">
+        <filters name="listing_filters"/>
+        <massaction name="listing_massaction">
+            <action name="aplazo_cancel_retries">
+                <settings>
+                    <url path="aplazo/refundrequest/massCancelRetries"/>
+                    <type>aplazo_cancel_retries</type>
+                    <label translate="true">Cancel retries</label>
+                    <confirm>
+                        <title translate="true">Cancel retries</title>
+                        <message translate="true">This will stop any further retries for the selected rows. Continue?</message>
+                    </confirm>
+                </settings>
+            </action>
+        </massaction>
+        <paging name="listing_paging">
+            <settings>
+                <selectProvider>aplazo_refund_request_listing.aplazo_refund_request_listing.aplazo_refund_request_columns.ids</selectProvider>
+            </settings>
+        </paging>
+    </listingToolbar>
+
+    <columns name="aplazo_refund_request_columns">
+        <selectionsColumn name="ids" sortOrder="0">
+            <settings>
+                <indexField>entity_id</indexField>
+            </settings>
+        </selectionsColumn>
+        <column name="entity_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">ID</label>
+                <sorting>asc</sorting>
+            </settings>
+        </column>
+        <column name="type">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Type</label>
+            </settings>
+        </column>
+        <column name="status">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Status</label>
+            </settings>
+        </column>
+        <column name="order_increment_id">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Order #</label>
+            </settings>
+        </column>
+        <column name="creditmemo_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">Creditmemo ID</label>
+            </settings>
+        </column>
+        <column name="rma_entity_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">RMA ID</label>
+            </settings>
+        </column>
+        <column name="rma_item_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">RMA Item ID</label>
+            </settings>
+        </column>
+        <column name="amount_cents">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">Amount (cents)</label>
+            </settings>
+        </column>
+        <column name="currency">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Currency</label>
+            </settings>
+        </column>
+        <column name="aplazo_refund_id">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Aplazo refundId</label>
+            </settings>
+        </column>
+        <column name="aplazo_refund_status">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Aplazo status</label>
+            </settings>
+        </column>
+        <column name="retries">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">Retries</label>
+            </settings>
+        </column>
+        <column name="last_error">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Last error</label>
+            </settings>
+        </column>
+        <column name="next_attempt_at">
+            <settings>
+                <filter>dateRange</filter>
+                <label translate="true">Next attempt</label>
+            </settings>
+        </column>
+        <column name="created_at">
+            <settings>
+                <filter>dateRange</filter>
+                <label translate="true">Created</label>
+            </settings>
+        </column>
+        <column name="updated_at">
+            <settings>
+                <filter>dateRange</filter>
+                <label translate="true">Updated</label>
+            </settings>
+        </column>
+    </columns>
+</listing>
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches refund execution flow by introducing new persistence, async processing, and external API calls with retries/locking; failures or schema/cron misconfiguration could delay or duplicate refunds despite added idempotency safeguards.
> 
> **Overview**
> Implements an **idempotent, persistent refund queue** backed by a new `aplazo_refund_request` table (unique by `type` + `idempotency_key`) and a full Magento repository/model layer to store payloads, responses, retry state, and Aplazo refund identifiers.
> 
> Refund creation is moved to *after-save* observers for credit memos and RMAs, which enqueue refund requests (deduping via the unique constraint) instead of making inline calls; a new `RefundQueueManagement` cron/CLI processor executes queued refunds with cache-based locking, retry/backoff, and order history annotations, plus an admin UI grid and mass action to cancel further retries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76a3dadfc859c00009dea0211c2502bf94b43253. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->