### PR TITLE
MG-150: improved events

### DIFF
--- a/Observer/RefundObserverAfterSave.php
+++ b/Observer/RefundObserverAfterSave.php
@@ -111,7 +111,6 @@ class RefundObserverAfterSave implements ObserverInterface
                 $this->trackingService->sendEvent(
                     TrackingService::EVENT_REFUND_CREATED,
                     [
-                        'platform' => $this->data->getPlatformCode(),
                         'order_id' => (int)$order->getEntityId(),
                         'order_increment_id' => (string)$order->getIncrementId(),
                         'creditmemo_id' => (int)$creditMemo->getEntityId(),

--- a/Service/TrackingService.php
+++ b/Service/TrackingService.php
@@ -94,15 +94,21 @@ class TrackingService
      */
     public function sendEvent(string $eventName, array $properties, array $context = [], array $identity = [], int $eventVersion = 1): void
     {
-        if (!$this->aplazoHelper->getTrackingEnabled()) {
-            return;
-        }
-
         if (!isset($context['shopName']) || !is_string($context['shopName']) || $context['shopName'] === '') {
             $context['shopName'] = $this->inferShopNameFromBaseUrl();
         }
 
         $merchantId = (string)$this->aplazoHelper->getMerchantId();
+        $properties = array_merge($properties, $context);
+        if ($merchantId !== '') {
+            $properties['merchantId'] = $merchantId;
+        }
+        foreach ($identity as $key => $value) {
+            if ($value === '') {
+                continue;
+            }
+            $properties[$key] = $value;
+        }
 
         $payload = [
             'eventId' => $this->uuidV4(),
@@ -114,40 +120,62 @@ class TrackingService
             'schemaVersion' => self::SCHEMA_VERSION,
             'eventVersion' => $eventVersion,
             'properties' => (object)$properties,
-            'context' => (object)$context,
         ];
 
-        if ($merchantId !== '') {
-            $payload['merchantId'] = $merchantId;
-        }
-
-        foreach ($identity as $key => $value) {
-            if ($value === '') {
-                continue;
-            }
-            $payload[$key] = $value;
-        }
+        $url = rtrim($this->aplazoHelper->getTrackingBaseUrl(), '/') . '/api/v1/tracking/events';
 
         try {
+            $this->aplazoHelper->log(
+                sprintf(
+                    "Tracking event request.\nEVENT: %s\nURL: %s\nPAYLOAD: %s",
+                    $eventName,
+                    $url,
+                    (string)json_encode($payload, JSON_UNESCAPED_SLASHES)
+                )
+            );
+
             $curl = $this->curlFactory->create();
             $curl->setOption(CURLOPT_CONNECTTIMEOUT, self::DEFAULT_CONNECT_TIMEOUT_SECONDS);
             $curl->setOption(CURLOPT_TIMEOUT, self::DEFAULT_TIMEOUT_SECONDS);
 
             $headers = ['Content-Type' => 'application/json'];
             $curl->setHeaders($headers);
-
-            $url = rtrim($this->aplazoHelper->getTrackingBaseUrl(), '/') . '/api/v1/tracking/events';
             $curl->post($url, json_encode($payload, JSON_UNESCAPED_SLASHES));
 
             $status = (int)$curl->getStatus();
+            $responseBody = (string)$curl->getBody();
+
+            $this->aplazoHelper->log(
+                sprintf(
+                    "Tracking event response.\nEVENT: %s\nURL: %s\nSTATUS: %s\nBODY: %s",
+                    $eventName,
+                    $url,
+                    $status,
+                    $responseBody
+                )
+            );
+
             if (!in_array($status, [200, 201, 202], true)) {
                 $this->aplazoHelper->log(
-                    sprintf('Tracking event failed. status=%s body=%s', $status, (string)$curl->getBody())
+                    sprintf(
+                        "Tracking event failed.\nEVENT: %s\nURL: %s\nSTATUS: %s\nBODY: %s",
+                        $eventName,
+                        $url,
+                        $status,
+                        $responseBody
+                    )
                 );
             }
         } catch (\Throwable $e) {
             // Never block commerce flows because of tracking.
-            $this->aplazoHelper->log('Tracking event exception: ' . $e->getMessage());
+            $this->aplazoHelper->log(
+                sprintf(
+                    "Tracking event exception.\nEVENT: %s\nURL: %s\nMESSAGE: %s",
+                    $eventName,
+                    $url,
+                    $e->getMessage()
+                )
+            );
         }
     }
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -117,14 +117,6 @@
                             <comment>Cuando aplazo confirme de pagado a través del Webhook, se enviará un correo de confirmación de pago al comprador.</comment>
                         </field>
                     </group>
-                    <group id="tracking" translate="label" type="text" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="0">
-                        <label>Tracking / Eventos</label>
-                        <field id="tracking_enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
-                            <label>Enviar eventos de tracking</label>
-                            <config_path>payment/aplazo_gateway/tracking_enabled</config_path>
-                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                        </field>
-                    </group>
                     <group id="abandoned_checkout" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Abandono de Checkout de Aplazo</label>
                         <field id="enable_cancel_on_abandoned_checkout" translate="label" type="select" sortOrder="34" showInDefault="1" showInWebsite="1" showInStore="0">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -32,7 +32,6 @@
                 <refund>1</refund>
                 <rma_refund>1</rma_refund>
                 <send_email>0</send_email>
-                <tracking_enabled>1</tracking_enabled>
             </aplazo_gateway>
         </payment>
     </default>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the analytics payload contract and removes the ability to disable tracking, which could impact downstream consumers and increase outbound traffic/log volume, though it does not affect core commerce flow.
> 
> **Overview**
> Tracking events are now always sent: the `tracking_enabled` admin setting and its default value were removed, and `TrackingService::sendEvent` no longer short-circuits on that flag.
> 
> `sendEvent` also changes the event schema by **merging `context`/identity/`merchantId` into `properties`** (dropping the separate `context` field) and adds detailed request/response/exception logging around the HTTP call. The refund-created observer also stops sending a redundant `platform` property.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97389cf1177ec34d4da9095088a689b88d051808. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->