### PR TITLE
MG-942: send MXN amounts to Aplazo when base currency differs from display

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -3,6 +3,7 @@
 namespace Aplazo\AplazoPayment\Helper;
 
 use Magento\Framework\View\LayoutFactory;
+use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Aplazo\AplazoPayment\Service\ApiService as AplazoService;
 
@@ -12,6 +13,7 @@ class Data extends \Magento\Payment\Helper\Data
     const APLAZO_WEBHOOK_RECEIVED = 'aplazo_webhook_received';
     const APLAZO_ORDER_CANCELLED = 'aplazo_order_cancelled';
     const LOGS_VVV = 2;
+    const APLAZO_CURRENCY = 'MXN';
     private const DEFAULT_TRACKING_BASE_URL_STG = 'https://core.aplazo.net';
     private const DEFAULT_TRACKING_BASE_URL_PROD = 'https://core.aplazo.mx';
     private const PLATFORM_CODE = 'MGT';
@@ -174,6 +176,31 @@ class Data extends \Magento\Payment\Helper\Data
         /** @var \Magento\Store\Model\Store $store */
         $store = $this->storeManager->getStore();
         return $store->getCurrentCurrency()->getCode();
+    }
+
+    /**
+     * Aplazo always settles in MXN and ignores the currency code, so every amount
+     * we send must already be expressed in pesos. This decides whether to read the
+     * order/display amounts (getX) or the base amounts (getBaseX):
+     *  - base == order currency (typical MXN/MXN): display equals base, default to display.
+     *  - they differ: send whichever side is actually MXN. If neither is MXN the store is
+     *    unsupported (the admin currency check already warns); default to display.
+     *
+     * @param OrderInterface $order
+     * @return bool true to use display (order-currency) amounts, false to use base amounts
+     */
+    public function shouldUseDisplayAmounts(OrderInterface $order): bool
+    {
+        $orderCurrency = (string)$order->getOrderCurrencyCode();
+        $baseCurrency = (string)$order->getBaseCurrencyCode();
+
+        if ($orderCurrency === '' || $orderCurrency === $baseCurrency) {
+            return true;
+        }
+        if ($baseCurrency === self::APLAZO_CURRENCY) {
+            return false;
+        }
+        return true;
     }
 
     public function getServiceUrl(){

--- a/Model/Service/OrderService.php
+++ b/Model/Service/OrderService.php
@@ -218,10 +218,13 @@ class OrderService
     {
         $result = ['success' => false, 'data' => '', 'message' => ''];
         try {
+            $useDisplayAmounts = $this->aplazoHelper->shouldUseDisplayAmounts($order);
             try{
                 $quote = $this->quoteRepository->get($order->getQuoteId());
                 $shippingMethod = $quote->getShippingAddress()->getShippingDescription();
-                $taxAmount = $quote->getShippingAddress()->getTaxAmount();
+                $taxAmount = $useDisplayAmounts
+                    ? $quote->getShippingAddress()->getTaxAmount()
+                    : $quote->getShippingAddress()->getBaseTaxAmount();
                 $extOrderId = $quote->getId();
             }catch (\Magento\Framework\Exception\NoSuchEntityException $e){
                 $shippingMethod = 'No info rate';
@@ -238,7 +241,7 @@ class OrderService
                         "description" => $item->getDescription(),
                         "id" => $item->getProductId(),
                         "imageUrl" => '',
-                        "price" => $item->getRowTotal() ?? 0,
+                        "price" => ($useDisplayAmounts ? $item->getRowTotal() : $item->getBaseRowTotal()) ?? 0,
                         "title" => $item->getName()
                     ];
                 }
@@ -257,13 +260,13 @@ class OrderService
                 "cartId" => $order->getIncrementId(),
                 "cartUrl" => $cartUrl,
                 "discount" => [
-                    "price" => abs($order->getBaseDiscountAmount()),
+                    "price" => abs($useDisplayAmounts ? $order->getDiscountAmount() : $order->getBaseDiscountAmount()),
                     "title" => $order->getShippingAddress()->getDiscountDescription()
                 ],
                 "errorUrl" => $this->aplazoHelper->getUrl('aplazo/order/operations', ['operation' => 'redirect_to_onepage', 'onepage' => 'failure', 'orderid' => $order->getIncrementId()]),
                 "products" => $products,
                 "shipping" => [
-                    "price" => abs($order->getBaseShippingAmount()),
+                    "price" => abs($useDisplayAmounts ? $order->getShippingAmount() : $order->getBaseShippingAmount()),
                     "title" => $shippingMethod
                 ],
                 "shopId" => $order->getIncrementId(),
@@ -273,10 +276,10 @@ class OrderService
                     "title" => __('Tax'),
                 ],
                 "extOrderId" => $extOrderId,
-                "totalPrice" => $order->getBaseGrandTotal(),
+                "totalPrice" => $useDisplayAmounts ? $order->getGrandTotal() : $order->getBaseGrandTotal(),
                 "webHookUrl" => $this->aplazoHelper->getUrl('rest/V1/aplazo') . 'callback'
             ];
-            $this->logService->send('info', 'Creating loan', ['module:checkout'], ['order_id' => $order->getIncrementId(), 'loan_payload' => $orderData]);
+            $this->logService->send('info', 'Creating loan', ['module:checkout'], ['order_id' => $order->getIncrementId(), 'loan_payload' => $orderData, 'base_currency' => $order->getBaseCurrencyCode(), 'order_currency' => $order->getOrderCurrencyCode(), 'use_display_amounts' => $useDisplayAmounts]);
             $this->aplazoHelper->log('OrderService->createLoan: Se manda a llamar el token de autorizacion', AplazoHelper::LOGS_VVV);
             $tokenBearer = $this->aplazoService->getAuthorizationToken();
             $this->aplazoHelper->log('OrderService->createLoan: Token de auth - '. $tokenBearer .'. Se creara el loan', AplazoHelper::LOGS_VVV);

--- a/Observer/RefundObserverAfterSave.php
+++ b/Observer/RefundObserverAfterSave.php
@@ -57,9 +57,12 @@ class RefundObserverAfterSave implements ObserverInterface
             return;
         }
 
-        $amount = (float)$creditMemo->getGrandTotal();
+        $useDisplayAmounts = $this->data->shouldUseDisplayAmounts($order);
+        $amount = (float)($useDisplayAmounts ? $creditMemo->getGrandTotal() : $creditMemo->getBaseGrandTotal());
         $amountCents = (int)round($amount * 100);
-        $currency = (string)($order->getOrderCurrencyCode() ?: $order->getBaseCurrencyCode() ?: '');
+        $currency = $useDisplayAmounts
+            ? (string)($order->getOrderCurrencyCode() ?: $order->getBaseCurrencyCode() ?: '')
+            : (string)($order->getBaseCurrencyCode() ?: $order->getOrderCurrencyCode() ?: '');
 
         $reason = '';
         foreach ($creditMemo->getComments() as $index => $comment) {

--- a/Observer/RefundObserverBeforeSave.php
+++ b/Observer/RefundObserverBeforeSave.php
@@ -81,7 +81,9 @@ class RefundObserverBeforeSave implements ObserverInterface
             return;
         }
 
-        $amountRefund = $creditMemo->getGrandTotal();
+        $amountRefund = $this->_data->shouldUseDisplayAmounts($order)
+            ? $creditMemo->getGrandTotal()
+            : $creditMemo->getBaseGrandTotal();
 
         $reason = '';
         foreach($creditMemo->getComments() as $index => $comment){

--- a/Observer/RmaObserverAfterSave.php
+++ b/Observer/RmaObserverAfterSave.php
@@ -11,6 +11,7 @@ use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Sales\Api\OrderItemRepositoryInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
 
 class RmaObserverAfterSave implements ObserverInterface
 {
@@ -22,6 +23,7 @@ class RmaObserverAfterSave implements ObserverInterface
         private RefundRequestFactory $refundRequestFactory,
         private RefundRequestRepositoryInterface $refundRequestRepository,
         private OrderItemRepositoryInterface $orderItemRepository,
+        private OrderRepositoryInterface $orderRepository,
         private ManagerInterface $messageManager,
         private Data $data
     ) {
@@ -48,7 +50,20 @@ class RmaObserverAfterSave implements ObserverInterface
         /** @var \Magento\Rma\Model\ItemFactory $itemFactory */
         $itemFactory = \Magento\Framework\App\ObjectManager::getInstance()->get('Magento\\Rma\\Model\\ItemFactory');
 
-        $currency = ''; // RMA does not always carry currency; keep optional.
+        // Aplazo always settles in MXN; resolve whether to send display or base amounts
+        // from the order's currencies. Falls back to display (previous behavior) if the
+        // order cannot be loaded.
+        $useDisplayAmounts = true;
+        $currency = '';
+        try {
+            $order = $this->orderRepository->get((int)$rma->getOrderId());
+            $useDisplayAmounts = $this->data->shouldUseDisplayAmounts($order);
+            $currency = $useDisplayAmounts
+                ? (string)($order->getOrderCurrencyCode() ?: '')
+                : (string)($order->getBaseCurrencyCode() ?: '');
+        } catch (\Throwable $e) {
+            // Could not resolve order currency; keep display amounts and empty currency.
+        }
 
         foreach ((array)$rma->getItems() as $item) {
             if (
@@ -73,7 +88,8 @@ class RmaObserverAfterSave implements ObserverInterface
             $orderItemId = (int)$item->getOrderItemId();
             $orderItem = $this->orderItemRepository->get($orderItemId);
 
-            $amount = (float)$orderItem->getPrice() * $qtyToSend;
+            $unitPrice = (float)($useDisplayAmounts ? $orderItem->getPrice() : $orderItem->getBasePrice());
+            $amount = $unitPrice * $qtyToSend;
             $amountCents = (int)round($amount * 100);
 
             $reason = (string)$item->getReason();
@@ -83,7 +99,7 @@ class RmaObserverAfterSave implements ObserverInterface
                 'rmaItemId' => (int)$item->getEntityId(),
                 'orderItemId' => $orderItemId,
                 'qtyToSend' => (float)$qtyToSend,
-                'unitPriceCents' => (int)round(((float)$orderItem->getPrice()) * 100),
+                'unitPriceCents' => (int)round($unitPrice * 100),
             ];
 
             $idempotencyKey = hash('sha256', json_encode([

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "aplazo/aplazopayment",
   "description": "Aplazo Payment Gateway for Magento 2",
   "type": "magento2-module",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Aplazo_AplazoPayment" setup_version="4.0.10">
+    <module name="Aplazo_AplazoPayment" setup_version="4.0.11">
         <sequence>
             <module name="Magento_Backend"/>
             <module name="Magento_Ui"/>


### PR DESCRIPTION
## Summary
Emergency fix (MG-942) for a merchant whose Magento store keeps **base currency in USD** but **display currency in MXN**. Aplazo always settles in MXN and ignores the currency code, so the loan was being created with the base-currency (USD) amount — e.g. an item of 15 USD reached Aplazo as `15` and was charged as **15 MXN** instead of the MXN equivalent.

The previous `createLoan` payload was also internally inconsistent: products/taxes used display-currency getters while totalPrice/shipping/discount used base-currency getters (invisible on MXN/MXN stores, broken when base ≠ display).

## Approach
New `Helper\Data::shouldUseDisplayAmounts(OrderInterface $order): bool` — **display amounts by default**; when base and order currencies differ, send whichever side is actually MXN.

| base | display | Result | Effect |
|------|---------|--------|--------|
| MXN | MXN | display (== base) | Identical to today, zero risk |
| USD | MXN | display | Fixes the reporting merchant |
| MXN | USD | base | Protects the inverse case |
| USD | EUR | display | Unsupported; admin currency check already warns |

Decided per order (each order stores its own currency codes), so historical refunds stay correct.

## Changes
- **OrderService::createLoan** — all five amounts (products, tax, discount, shipping, totalPrice) use a single currency source; added `base_currency` / `order_currency` / `use_display_amounts` to the loan log.
- **RefundObserverBeforeSave** — credit memo amount via `getGrandTotal`/`getBaseGrandTotal`.
- **RefundObserverAfterSave** — same, and the persisted `currency` is aligned with the amount (it feeds the idempotency key).
- **RmaObserverAfterSave** — injects `OrderRepositoryInterface`, resolves the order currency, uses `getPrice`/`getBasePrice`; falls back to display (previous behavior) if the order can't be loaded.
- Version bump **4.0.10 → 4.0.11** (`composer.json`, `etc/module.xml`).

## Validation
- `php -l` clean on all edited files.
- `dev:di:info` confirms the new `RmaObserverAfterSave` dependency resolves.
- Pending: functional test with USD/MXN and MXN/MXN orders (verify payload + reconciliation `sum(products)+shipping+tax-discount ≈ totalPrice`).

Ticket: https://aplazo.atlassian.net/browse/MG-942

🤖 Generated with [Claude Code](https://claude.com/claude-code)