### PR TITLE
BNPL-1018: Add Backstage catalog-info and TechDocs (Magento 2)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,36 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: aplazo-magento-2-payment-gateway
+  title: Aplazo Payment Gateway for Magento 2
+  description: |
+    Magento 2 (Adobe Commerce) payment method that lets shoppers pay with Aplazo
+    (Buy Now, Pay Later — "en quincenas"). Handles loan creation at checkout,
+    redirect to the Aplazo hosted checkout, order confirmation via a JWT-signed
+    webhook, cancellation of unpaid orders, and a resilient refund/RMA queue.
+  tags:
+    - plugin
+    - payment-gateway
+    - magento
+    - php
+    - bnpl
+    - ecommerce
+  annotations:
+    backstage.io/techdocs-ref: dir:./docs
+    github.com/project-slug: aplazo/php.aplazo-magento-2-payment-gateway
+    # NOTE: add these once available for this repo (PHP plugin repos are not in Sonar today):
+    # sonarqube.org/project-key: <KEY>
+    # aws.amazon.com/amazon-ecs-service-arn: <ARN>
+    # jenkins.io/job-full-name: <JOB>
+  links:
+    - url: https://web.aplazo.mx/merchant-registration/become-merchant/company-info
+      title: Become an Aplazo merchant
+      icon: web
+spec:
+  type: library          # Distributed as a Composer module (magento2-module), not a running service
+  lifecycle: production
+  # TODO: verify against https://github.com/aplazo/yaml.aplazo-platform-catalog
+  # Current squad is "merchant-growth"; ownership is expected to move to the new
+  # "bnpl-online" squad after the engineering restructure.
+  owner: group:default/merchant-growth
+  system: system:default/bnpl-online

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,39 @@
+site_name: Aplazo Payment Gateway for Magento 2
+site_description: Documentation for the Aplazo Payment Gateway Magento 2 module
+site_url: https://backstage.aplazo.dev/catalog/default/component/aplazo-magento-2-payment-gateway
+repo_url: https://github.com/aplazo/php.aplazo-magento-2-payment-gateway
+repo_name: aplazo/php.aplazo-magento-2-payment-gateway
+docs_dir: ./src
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Configuration: configuration.md
+  - Checkout Flow: checkout-flow.md
+  - Webhook & Callbacks: webhooks.md
+  - API Reference: api-reference.md
+  - Refunds & RMA: refunds.md
+  - Cron & CLI: cron-and-cli.md
+  - Data Model: data-model.md
+  - Observability: observability.md
+  - Troubleshooting: troubleshooting.md
+
+plugins:
+  - search
+  - techdocs-core
+
+markdown_extensions:
+  - toc:
+      permalink: true
+  - codehilite
+  - tables
+  - admonition
+  - pymdownx.superfences
+  - pymdownx.tabbed
+  - pymdownx.details
+  - pymdownx.emoji
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -1,0 +1,102 @@
+# API Reference
+
+Two directions:
+
+- **Outbound** — calls the module makes to Aplazo.
+- **Inbound** — REST endpoints the store exposes for Aplazo to call.
+
+## Base URLs
+
+Selected by the **Modo de pruebas** (`sanbox_mode`) toggle:
+
+| Purpose | Sandbox | Production | Resolver |
+|---|---|---|---|
+| Transactional API | `https://api.aplazo.net` | `https://api.aplazo.mx` | `Helper\Data::getServiceUrl()` |
+| Core (tracking & logs) | `https://core.aplazo.net` | `https://core.aplazo.mx` | `Helper\Data::getTrackingBaseUrl()` |
+
+## Outbound — Aplazo transactional API
+
+All requests are made with `Magento\Framework\HTTP\Client\Curl` (connect timeout 10s,
+timeout 90s) and carry these headers:
+
+```
+merchant_id:  <configured Merchant ID>
+api_token:    <decrypted API token>
+Content-Type: application/json
+Authorization: <bearer>        # only when a bearer token applies
+X-Idempotency-Key: <key>       # refunds only
+```
+
+Success is any of HTTP `200/201/202`; anything else raises a `LocalizedException`.
+
+| Operation | Method & path | Caller | Notes |
+|---|---|---|---|
+| Authenticate | `POST /api/auth` | `getAuthorizationToken()` | Body `{ apiToken, merchantId }` → response `{ Authorization }`. Used to validate credentials. |
+| Create loan | `POST /api/loan` | `createLoan()` | Returns `{ url }` = Aplazo hosted-checkout URL. |
+| Loan status | `GET /api/pos/loan/{cartId}` | `getLoanStatus()` | Returns array of loans; status `OUTSTANDING` = paid. |
+| Refund | `POST /api/pos/loan/refund` | `createRefund()` | Sends `X-Idempotency-Key`. Response `{ refundId, refundStatus }`. |
+| Cancel loan | `POST /api/pos/loan/cancel` | `cancelLoan()` | Body includes `cartId`, `reason`. |
+
+`refundStatus` values handled: `REQUESTED` (success), `REJECTED` (permanent failure),
+anything else → retried. See [Refunds & RMA](refunds.md).
+
+## Outbound — Core (tracking & logs)
+
+### Analytics events
+
+```
+POST {coreBaseUrl}/api/v1/tracking/events
+Content-Type: application/json
+```
+
+Fire-and-forget (connect 2s / timeout 5s); failures never block commerce. Payload
+envelope:
+
+```json
+{
+  "eventId": "<uuid v4>",
+  "eventName": "order_paid",
+  "occurredAt": "2026-01-01T00:00:00Z",
+  "source": "MGT",
+  "environment": "prod",
+  "schemaVersion": 1,
+  "eventVersion": 1,
+  "properties": { "merchantId": "...", "orderIncrementId": "...", "...": "..." }
+}
+```
+
+Event names (kept stable — they are an analytics contract):
+`plugin_installed`, `plugin_uninstalled`, `order_created`, `order_paid`,
+`refund_created`.
+
+### Remote logs
+
+```
+POST {coreBaseUrl}/api/v1/ps/logs
+Content-Type: application/json
+```
+
+Structured logs with `platform: "magento"`, `plugin: "aplazo-payment-gateway"`,
+`merchant_id`, `environment`, `level`, `message`, `request_id` (correlates a whole
+request), `tags`, and `attributes`. Also fire-and-forget. See
+[Observability](observability.md).
+
+## Inbound — REST endpoints exposed (`etc/webapi.xml`)
+
+| Method & path | Auth (resource) | Service |
+|---|---|---|
+| `POST /V1/aplazo/callback/` | `anonymous` (+ JWT) | `NotificationsInterface::notify` |
+| `POST /V1/aplazo/checkout-not-paid` | `Magento_Sales::cancel` | `CheckoutNotPaidManagementInterface::postCheckoutNotPaid` |
+
+Full details in [Webhook & Callbacks](webhooks.md).
+
+## Frontend controller routes
+
+Route front name `aplazo` (`etc/frontend/routes.xml`), admin route `aplazo`
+(`etc/adminhtml/routes.xml`).
+
+| URL | Operation | Purpose |
+|---|---|---|
+| `aplazo/order/operations?operation=purchase` | `purchase` | Redirect to Aplazo checkout |
+| `aplazo/order/operations?operation=cancel` | `cancel` | Handle abandoned checkout (token-guarded) |
+| `aplazo/order/operations?operation=redirect_to_onepage` | `redirectToOnepage` | Success/failure redirect |

--- a/docs/src/checkout-flow.md
+++ b/docs/src/checkout-flow.md
@@ -1,0 +1,96 @@
+# Checkout Flow
+
+This is the end-to-end happy path plus the abandon / cancel branches.
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    participant S as Shopper
+    participant M as Magento
+    participant O as Observer<br/>(sales_order_place_after)
+    participant A as Aplazo API<br/>(api.aplazo.mx)
+    participant C as Aplazo Checkout
+    participant W as Webhook<br/>(V1/aplazo/callback)
+
+    S->>M: Place order with "aplazo_gateway"
+    M->>O: sales_order_place_after
+    O->>A: POST /api/loan (order payload + random cancel token)
+    A-->>O: { url: <aplazo checkout url> }
+    O->>M: Save sales_order.aplazo_checkout_url = url||token<br/>status = order_status (pending)
+    S->>M: GET aplazo/order/operations?operation=purchase
+    M->>M: Reserve stock (reservingStockUntilPayment)
+    M-->>S: 302 redirect to Aplazo checkout
+    S->>C: Completes installment plan
+    C->>W: POST /V1/aplazo/callback (JWT Bearer, HS512)
+    W->>M: status "Activo" → approveOrder + invoice
+    W-->>C: { status: true }
+    M-->>S: Redirect to success (aplazo/order/operations?operation=redirect_to_onepage&onepage=success)
+```
+
+## Step by step
+
+### 1. Order placement → loan creation
+
+`Observer\SalesOrderPlaceAfterCreateLoan` listens to `sales_order_place_after`. When
+the order's payment method is `aplazo_gateway` it:
+
+1. Generates a 16-char random **cancel token**.
+2. Fires an `order_created` tracking event (best-effort).
+3. Calls `OrderService::createLoan()` → `ApiService::createLoan()` →
+   `POST {serviceUrl}/api/loan`.
+4. On a response containing `url`, stores it on the order as
+   `aplazo_checkout_url = "<url>||<token>"` and sets the order status to
+   `order_status` (default `pending`).
+
+If no `url` comes back, an error is logged and the order has no redirect URL.
+
+### 2. Redirect to Aplazo
+
+The frontend controller `aplazo/order/operations` (`Controller\Order\Operations`)
+dispatches by `operation` param:
+
+- **`purchase`** — reserves stock, splits `url||token`, and 302-redirects to the
+  Aplazo checkout URL. If the URL is missing it redirects back to `checkout/cart`
+  with an error.
+- **`cancel`** — used when the shopper abandons the Aplazo checkout (see
+  [Webhook & Callbacks → abandoned checkout](webhooks.md#abandoned-checkout)).
+- **`redirect_to_onepage`** — restores the quote/order in session and sends the
+  shopper to `checkout/onepage/success` or `.../failure`.
+
+### 3. Payment confirmation (webhook)
+
+Aplazo calls `POST /V1/aplazo/callback` with a JWT. On `status = "Activo"` the order
+is approved (`approveOrder`), optionally invoiced and emailed, and the loan id/status
+are stored in payment additional information. See [Webhook & Callbacks](webhooks.md).
+
+### 4. Stock reservation
+
+When `reserve_stock` is enabled, inventory is held from redirect until the webhook
+confirms payment. On cancellation, `Observer\Order\CancelAfter` (event
+`order_cancel_after`) compensates stock.
+
+## Abandon / not-paid branch
+
+```mermaid
+flowchart TD
+    A[Shopper leaves Aplazo checkout] --> B{cancel_active?}
+    B -- yes --> C[Operations::cancel with token]
+    C --> D[postCheckoutNotPaid increment_id]
+    D --> E[Cancel order + clear session]
+    E --> F{recover_active?}
+    F -- yes --> G[Rebuild quote from order items → replaceQuote]
+    F -- no --> H[Redirect to cart with cancel_message]
+    B -- no --> I[Order stays pending → cron will resolve it]
+```
+
+## Safety-net cron
+
+Independently of the webhook, the **cancel-orders cron** (every 15 min) looks at
+orders older than `cancel_time` minutes and, for each, checks the loan status in
+Aplazo:
+
+- If any loan is `OUTSTANDING` → the order is **recovered** (approved/invoiced).
+- Otherwise → the order is **cancelled**.
+
+See [Cron & CLI](cron-and-cli.md).

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,0 +1,65 @@
+# Configuration
+
+All settings live under **Stores → Configuration → Sales → Payment Methods → Aplazo**
+and are stored under the config path prefix `payment/aplazo_gateway/`. Values are read
+at `store` scope through `Aplazo\AplazoPayment\Helper\Data`.
+
+## Credentials & status
+
+| Field (admin) | Config path | Type | Notes |
+|---|---|---|---|
+| Merchant ID | `payment/aplazo_gateway/merchantid` | text | Sent as `merchant_id` header on every API call. Invalidates cache on change. |
+| API token | `payment/aplazo_gateway/apitoken` | obscure | **Encrypted at rest**; decrypted via `EncryptorInterface`. Also used as the **HS512 key** to verify the webhook JWT. |
+| Modo de pruebas | `payment/aplazo_gateway/sanbox_mode` | select | Switches all base URLs between sandbox and production. |
+| Estado de credenciales | _(display)_ | block | Live validation badge (`CredentialsStatus`). |
+| Moneda configurada | _(display)_ | block | Store currency; **must be `MXN`** or the method stays hidden. |
+
+Credentials are considered valid when `CredentialsValidator::areCredentialsValid()`
+returns true — i.e. an auth token is successfully obtained from Aplazo **and** the
+store currency is `MXN`.
+
+## General
+
+| Field | Config path | Default | Purpose |
+|---|---|---|---|
+| Activar | `active` | 1 | Enable/disable the method. |
+| Posición en el checkout | `sort_order` | 1 | Ordering vs other methods. |
+| Estado de orden nueva | `order_status` | `pending` | Status when the order is first created. |
+| Estado de orden aprobada | `approved_order_status` | `processing` | Status after the webhook confirms payment. |
+| Estado de orden rechazada | `failure_order_status` | `canceled` | Status on failure. |
+| Reservar stock | `reserve_stock` | 1 | Reserve inventory until the webhook confirms payment. |
+| Tiempo en que se cancelan las órdenes | `cancel_time` | 720 (min) | Age after which unpaid orders are cancelled by cron. |
+| Mostrar widget en página de producto | `show_on_product_page` | 1 | Product-page installment widget. |
+| Mostrar widget en página de carrito | `show_on_cart` | 1 | Cart-page installment widget. |
+| Habilitar reembolsos | `refund` | 1 | Enqueue refunds on credit memo. |
+| Habilitar reembolsos por RMA | `rma_refund` | 1 | Enqueue refunds on RMA (Adobe Commerce). |
+| Enviar correo de confirmación en webhook | `send_email` | 0 | Send the order-confirmation email when the webhook confirms payment. |
+
+## Abandoned checkout
+
+| Field | Config path | Default | Purpose |
+|---|---|---|---|
+| Cancelar orden si el usuario abandona checkout | `cancel_active` | 1 | Cancel the order when the shopper leaves the Aplazo checkout. |
+| Mensaje a mostrar | `cancel_message` | _(see below)_ | Shown on redirect back to cart. |
+| Recuperar carrito al regresar | `recover_active` / `enable_recover_cart` | 1 | Rebuild a cart from the abandoned order's items. |
+
+> Default cancel message: _"No terminaste la orden con Aplazo. La orden se canceló.
+> Por favor, intenta nuevamente."_
+
+## Test & Debug
+
+| Field | Config path | Default | Purpose |
+|---|---|---|---|
+| Activar logs | `debug_mode` | 1 | Log verbosity (`1` = normal, `2` = very verbose / `LOGS_VVV`). |
+| Check Healthy Site | `check_healthy_site` | 0 | On save, fires test requests to Aplazo to verify connectivity. Results in `var/log/aplazo_payment/info.log`. |
+
+## Payment method behavior (`etc/config.xml`)
+
+The method is an **offsite gateway**: `can_authorize`, `can_capture`, `can_void`,
+and `is_gateway` are all `0` — Magento does not capture funds; Aplazo does. Model
+facade is `AplazoFacade`, `can_use_checkout = 1`, `allowspecific = 1`.
+
+!!! warning "Credentials are secrets"
+    The API token is encrypted in the DB and doubles as the webhook signing key.
+    Never commit real credentials, and rotate them through the admin (which
+    re-encrypts and invalidates cache) rather than editing the database directly.

--- a/docs/src/cron-and-cli.md
+++ b/docs/src/cron-and-cli.md
@@ -1,0 +1,47 @@
+# Cron & CLI
+
+## Cron jobs (`etc/crontab.xml`, group `default`)
+
+| Job name | Class | Schedule | Purpose |
+|---|---|---|---|
+| `aplazo_aplazopayment_cancel_orders` | `Cron\CancelOrders` | `*/15 * * * *` | Resolve stale unpaid Aplazo orders |
+| `aplazo_aplazopayment_process_refund_queue` | `Cron\ProcessRefundQueue` | `*/5 * * * *` | Drain the refund queue |
+
+Both require Magento cron to be running (`bin/magento cron:run` via system crontab).
+
+### Cancel orders (every 15 min)
+
+Only runs when `cancel_time` is set. It collects orders older than `cancel_time`
+minutes and, per order, calls `ApiService::shouldCancelOrder()` which reads the loan
+status from Aplazo (`GET /api/pos/loan/{incrementId}`):
+
+```mermaid
+flowchart TD
+    A[Collect orders older than cancel_time] --> B{Loan OUTSTANDING in Aplazo?}
+    B -- yes --> C{status == aplazo_webhook_received?}
+    C -- yes --> D[Create invoice → approved_order_status]
+    C -- no --> E[approveOrder → mark paid]
+    B -- no --> F[cancelOrder]
+    D --> G[Add history comment + remote log]
+    E --> G
+    F --> G
+```
+
+This is the safety net for missed/failed webhooks: a paid order is **recovered**, an
+unpaid one is **cancelled**. Cancellation triggers `order_cancel_after` →
+`Observer\Order\CancelAfter` for stock compensation, and the cancel is also propagated
+to Aplazo (`/api/pos/loan/cancel`) even if the Magento-side cancel fails.
+
+### Process refund queue (every 5 min)
+
+Delegates to `RefundQueueManagement::process()`. Full logic in
+[Refunds & RMA](refunds.md).
+
+## Console commands
+
+| Command | Description |
+|---|---|
+| `php bin/magento aplazo:orders:cancel` | Run the cancel-orders logic manually (same as the 15-min cron) |
+| `php bin/magento aplazo:refund:process` | Process queued refunds now (same as the 5-min cron) |
+
+Use these for on-demand runs while debugging, or after a cron outage to catch up.

--- a/docs/src/data-model.md
+++ b/docs/src/data-model.md
@@ -1,0 +1,59 @@
+# Data Model
+
+Declarative schema lives in `etc/db_schema.xml`; custom order statuses and attributes
+are added by data patches in `Setup/Patch/Data`.
+
+## `sales_order` (extended)
+
+| Column | Type | Purpose |
+|---|---|---|
+| `aplazo_checkout_url` | `varchar(255)` | Aplazo hosted-checkout URL, stored as `"<url>||<cancel token>"`. The `purchase` action uses the URL; the `cancel` action requires the token. |
+
+## `aplazo_refund_request` (queue)
+
+Queue of pending/failed refunds and RMA refunds.
+
+| Column | Type | Notes |
+|---|---|---|
+| `entity_id` | int, PK, identity | |
+| `type` | varchar(32) | `refund` or `rma` |
+| `status` | varchar(16) | `pending` (default), `processing`, `success`, `failed` |
+| `order_increment_id` | varchar(32) | |
+| `order_id` | int, nullable | Order entity id |
+| `creditmemo_id` | int, nullable | |
+| `rma_entity_id`, `rma_item_id`, `order_item_id` | int, nullable | RMA linkage |
+| `qty` | decimal(12,4), nullable | Qty to refund (RMA) |
+| `amount_cents` | int | Refund amount in cents |
+| `currency` | varchar(8), nullable | |
+| `reason`, `reason_hash`, `items_hash` | text / varchar(64) | Dedup/audit helpers |
+| `idempotency_key` | varchar(64) | Sent as `X-Idempotency-Key` |
+| `payload_json` | text | Request payload sent to Aplazo |
+| `response_json` | text, nullable | Aplazo response |
+| `aplazo_refund_id`, `aplazo_refund_status` | varchar | From the Aplazo response |
+| `retries` | int, default 0 | |
+| `last_error` | text, nullable | |
+| `next_attempt_at` | timestamp, nullable | Backoff scheduling |
+| `created_at` / `updated_at` | timestamp | Auto-managed |
+
+**Constraints & indexes**
+
+- Unique `(type, idempotency_key)` — enforces at-most-once submission.
+- Index `(status, next_attempt_at)` — drives the queue selection query.
+
+## Custom order statuses (data patches)
+
+| Status code | Added by | Meaning |
+|---|---|---|
+| `aplazo_webhook_received` | `AddAplazoWebhookReceivedStatus` | Webhook received; invoice pending (finalized by cron). |
+| `aplazo_order_canceled` | `AddAplazoOrderCanceled` | Order that could not be cancelled cleanly; prevents endless cron re-processing. |
+
+## RMA item attribute
+
+| Attribute | Added by | Purpose |
+|---|---|---|
+| `qty_aplazo_refunded` | `AddQtyAplazoRefundedItemAttribute` | Tracks how much of an RMA item has already been refunded through Aplazo (Adobe Commerce only). |
+
+## Install/uninstall side effects
+
+- `SendModuleInstalledTrackingEvent` (data patch) → emits `plugin_installed`.
+- `Setup\Uninstall` → emits `plugin_uninstalled`.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -1,0 +1,70 @@
+# Getting Started
+
+## Requirements
+
+- Magento 2 / Adobe Commerce (tested on 2.4.x; PHP 8.2 supported).
+- Modules present in the store (declared as a `sequence` in `etc/module.xml`):
+  `Magento_Backend`, `Magento_Ui`, `Magento_Authorization`, `Magento_Sales`,
+  `Magento_Payment`, `Magento_Checkout`.
+- Composer dependency `firebase/php-jwt ^6.0` (installed automatically).
+- A store currency of **MXN** — the method is disabled for any other currency
+  (see [Configuration → Credentials](configuration.md#credentials--status)).
+- Aplazo **Merchant ID** and **API token** (request them at
+  [become a merchant](https://web.aplazo.mx/merchant-registration/become-merchant/company-info)).
+
+## Installation
+
+```bash
+# 1. Require the module
+composer require aplazo/aplazopayment
+
+# 2. Enable it
+php bin/magento module:enable Aplazo_AplazoPayment
+
+# 3. Run setup upgrade (installs DB schema + data patches)
+php bin/magento setup:upgrade
+
+# 4. Recompile & flush (production mode)
+php bin/magento setup:di:compile
+php bin/magento cache:flush
+```
+
+`setup:upgrade` applies the module's declarative schema and data patches:
+
+- Adds the `aplazo_checkout_url` column to `sales_order`.
+- Creates the `aplazo_refund_request` queue table.
+- Registers the custom order statuses `aplazo_webhook_received` and
+  `aplazo_order_canceled`.
+- Adds the `qty_aplazo_refunded` attribute to RMA items (Adobe Commerce only).
+- Emits a `plugin_installed` tracking event to Aplazo.
+
+## Configuration
+
+1. Go to **Stores → Configuration → Sales → Payment Methods → Aplazo**.
+2. Under **APLAZO checkout → Credenciales**, enter your **Merchant ID** and
+   **API token**, and pick **Modo de pruebas** (sandbox) if you are testing.
+3. Under **General**, set **Activar = Yes** and adjust order statuses, widgets,
+   refunds, and cancellation behavior as needed.
+4. Save. On save the module validates credentials against Aplazo and shows an
+   **Estado de credenciales** badge and the **Moneda configurada** (must be MXN).
+5. Flush the cache. The **"Compra ahora y paga en 5 quincenas"** method should now
+   appear at checkout.
+
+!!! tip "Sandbox vs Production"
+    A single **Modo de pruebas** toggle switches every outbound base URL at once:
+
+    | | Sandbox (test) | Production |
+    |---|---|---|
+    | API | `https://api.aplazo.net` | `https://api.aplazo.mx` |
+    | Core (tracking/logs) | `https://core.aplazo.net` | `https://core.aplazo.mx` |
+
+## Verify the install
+
+```bash
+# Confirm the module is enabled
+php bin/magento module:status Aplazo_AplazoPayment
+
+# Trigger the built-in health check (or enable "Check Healthy Site" in admin)
+# and watch the log:
+tail -f var/log/aplazo_payment/info.log
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,72 @@
+# Aplazo Payment Gateway for Magento 2
+
+Magento 2 / Adobe Commerce payment module that adds **Aplazo** (Buy Now, Pay Later —
+_"paga en 5 quincenas"_) as a checkout payment method.
+
+- **Module name:** `Aplazo_AplazoPayment`
+- **Composer package:** `aplazo/aplazopayment`
+- **Payment method code:** `aplazo_gateway`
+- **Current version:** `4.0.10`
+- **Tracking platform code:** `MGT`
+- **Runtime dependency:** [`firebase/php-jwt`](https://github.com/firebase/php-jwt) `^6.0`
+
+## What it does
+
+The merchant receives 100% of the order value up front; Aplazo finances the shopper
+in installments. The module orchestrates the full lifecycle:
+
+1. Renders the Aplazo method at checkout and on product/cart pages (widgets).
+2. On order placement, creates a **loan** in Aplazo and redirects the shopper to the
+   Aplazo hosted checkout.
+3. Confirms the order asynchronously through a **JWT-signed webhook**.
+4. **Cancels** unpaid orders (abandoned checkout + a safety-net cron).
+5. Processes **refunds and RMA** through a resilient, idempotent queue.
+6. Emits **analytics events** and **remote logs** to Aplazo for observability.
+
+## Architecture at a glance
+
+```mermaid
+flowchart LR
+    Shopper((Shopper))
+    subgraph Magento["Magento 2 store"]
+        Checkout[Checkout / method aplazo_gateway]
+        Observer[sales_order_place_after observer]
+        Ops[Controller aplazo/order/operations]
+        WebAPI[REST V1/aplazo/callback + checkout-not-paid]
+        Cron[Crons: cancel orders / refund queue]
+        DB[(sales_order + aplazo_refund_request)]
+    end
+    subgraph Aplazo["Aplazo backend"]
+        API[api.aplazo.mx / api.aplazo.net]
+        Core[core.aplazo.mx / core.aplazo.net]
+        AplazoCO[Aplazo hosted checkout]
+    end
+
+    Shopper --> Checkout --> Observer -->|POST /api/loan| API
+    Observer --> DB
+    Ops -->|redirect| AplazoCO
+    Shopper --> Ops
+    AplazoCO -->|webhook JWT| WebAPI --> DB
+    Cron -->|status / cancel / refund| API
+    Magento -->|events + logs| Core
+```
+
+## Documentation map
+
+| Page | What you'll find |
+|------|------------------|
+| [Getting Started](getting-started.md) | Install, enable, configure credentials |
+| [Configuration](configuration.md) | Every admin field and its config path |
+| [Checkout Flow](checkout-flow.md) | Order → loan → redirect → confirmation, step by step |
+| [Webhook & Callbacks](webhooks.md) | The JWT-signed callback and abandoned-checkout endpoint |
+| [API Reference](api-reference.md) | Aplazo endpoints consumed + REST endpoints exposed |
+| [Refunds & RMA](refunds.md) | The refund queue, retries, idempotency, RMA |
+| [Cron & CLI](cron-and-cli.md) | Scheduled jobs and console commands |
+| [Data Model](data-model.md) | DB tables, order columns, custom statuses |
+| [Observability](observability.md) | Logging (local + remote) and tracking events |
+| [Troubleshooting](troubleshooting.md) | Common problems and how to diagnose them |
+
+!!! note "Ownership"
+    Squad **merchant-growth** today; ownership is expected to move to the new
+    **bnpl-online** squad after the engineering restructure. Verify entity
+    references in [`yaml.aplazo-platform-catalog`](https://github.com/aplazo/yaml.aplazo-platform-catalog).

--- a/docs/src/observability.md
+++ b/docs/src/observability.md
@@ -1,0 +1,67 @@
+# Observability
+
+The module has three complementary signals: **local logs**, **remote logs**, and
+**analytics events**.
+
+## Local logs
+
+`Helper\Data::log()` writes through a dedicated logger.
+
+- Main file: `var/log/aplazo_payments.log`.
+- Health check file: `var/log/aplazo_payment/info.log` (see `Logger\Handler\InfoHandler`).
+- Verbosity is controlled by **Activar logs** (`debug_mode`):
+  - `1` → normal logging.
+  - `2` (`LOGS_VVV`) → very verbose (full request/response dumps, redirect traces).
+
+## Remote logs (`LogService`)
+
+Structured logs are shipped to Aplazo Core so the platform team can debug merchant
+issues without shell access:
+
+```
+POST {coreBaseUrl}/api/v1/ps/logs
+```
+
+- Fire-and-forget (connect 2s / timeout 5s) — never blocks commerce flows.
+- Correlation: a `request_id` (UUID v4) is generated per request and reused across all
+  log lines of that request. `resetRequestId()` is called at the start of each webhook,
+  cron, and cancel operation to start a fresh correlation id.
+- Constant fields: `platform: "magento"`, `plugin: "aplazo-payment-gateway"`,
+  `merchant_id`, `merchant_name`, `store_url`, `plugin_version`, `environment`
+  (`staging`/`production`), `level`, `tags` (e.g. `module:webhook`, `module:refund`,
+  `module:cron`, `module:checkout`, `module:cancel`, `module:http`).
+
+### Log tags cheat-sheet
+
+| Tag | Emitted from |
+|---|---|
+| `module:checkout` | Loan creation on order placement |
+| `module:webhook` | Payment confirmation callback |
+| `module:cancel` | Abandoned checkout / order cancel |
+| `module:cron` | Cancel-orders cron & loan-status checks |
+| `module:refund` | Refund queue processing |
+| `module:http` | Low-level HTTP failures |
+
+## Analytics events (`TrackingService`)
+
+Business events sent to `POST {coreBaseUrl}/api/v1/tracking/events` with
+`source = "MGT"`:
+
+| Event | When |
+|---|---|
+| `plugin_installed` | Module installed (data patch) |
+| `plugin_uninstalled` | Module uninstalled |
+| `order_created` | Order placed with Aplazo |
+| `order_paid` | Webhook confirms payment |
+| `refund_created` | Refund created |
+
+Events include `merchantId`, `shopName` (inferred from the store base URL), store/order
+properties, `schemaVersion`, and `environment`. Like remote logs, they are
+best-effort and never block the shopper.
+
+## Health check
+
+Enabling **Check Healthy Site** (`check_healthy_site`) and saving the payment config
+fires the `admin_system_config_changed_section_payment` event →
+`Observer\HealthySite`, which runs connectivity probes against Aplazo and writes the
+outcome to `var/log/aplazo_payment/info.log`. Turn it off after verifying.

--- a/docs/src/refunds.md
+++ b/docs/src/refunds.md
@@ -1,0 +1,80 @@
+# Refunds & RMA
+
+Refunds are **not** sent to Aplazo synchronously. They are enqueued and processed by a
+cron with retries, idempotency, and locking — so a transient Aplazo/network failure
+never loses a refund.
+
+## How refunds are enqueued
+
+| Trigger (event) | Observer | Queue `type` | Guard |
+|---|---|---|---|
+| Credit memo saved (`sales_order_creditmemo_save_after`) | `RefundObserverAfterSave` | `refund` | `refund` config enabled |
+| RMA saved (`rma_save_after`, Adobe Commerce) | `RmaObserverAfterSave` | `rma` | `rma_refund` config enabled |
+
+Each enqueues a row in `aplazo_refund_request` with the computed payload, an
+**idempotency key**, amount in cents, and status `pending`.
+
+## Processing
+
+```mermaid
+flowchart TD
+    A[Cron every 5 min: ProcessRefundQueue] --> B[RefundQueueManagement::process batch=20]
+    B --> C{pending & next_attempt_at <= now?}
+    C -- yes --> D[Acquire RefundLock type#124;idempotencyKey]
+    D -->|lock busy| C
+    D -->|acquired| E[status=processing → POST /api/pos/loan/refund]
+    E --> F{response}
+    F -->|refundStatus REQUESTED| G[status=success + store refundId]
+    F -->|refundStatus REJECTED| H[status=failed - permanent]
+    F -->|no refundId / unexpected| I[scheduleRetry]
+    I --> J{retries >= 5?}
+    J -- yes --> K[status=failed permanently]
+    J -- no --> L[retries++, set next_attempt_at with backoff]
+```
+
+- **Batch size:** 20 per run.
+- **Selection:** `status = pending` AND (`next_attempt_at IS NULL` OR `<= now`),
+  oldest first.
+- **Locking:** `RefundLock` keyed by `type|idempotencyKey` prevents parallel
+  processing across multiple cron workers. Lock contention does **not** consume the
+  retry budget.
+- **Idempotency:** the `X-Idempotency-Key` header + a unique DB constraint on
+  `(type, idempotency_key)` guarantee a refund is submitted at most once even across
+  retries.
+
+## Retry & backoff
+
+Max **5** retries. Backoff schedule (minutes) by prior retry count:
+
+| Retry # | 0→1 | 1→2 | 2→3 | 3→4 | 4→5 |
+|---|---|---|---|---|---|
+| Wait | 1m | 5m | 15m | 60m | 180m |
+
+After the 5th failed attempt the request is marked `failed` and a note is added to the
+order's status history.
+
+## Response handling
+
+| `refundStatus` | Outcome |
+|---|---|
+| `REQUESTED` | `success` — store `aplazo_refund_id`; for `rma` type, increment `qty_aplazo_refunded` on the RMA item |
+| `REJECTED` | `failed` — permanent; order history annotated |
+| missing `refundId` | retry (backoff 1m) |
+| any other value | retry (backoff 5m) |
+
+Every terminal outcome appends a comment to the order status history
+(e.g. _"Aplazo refund processed successfully. RefundId: …"_).
+
+## Admin visibility
+
+An **Aplazo refund queue** grid is available under Sales (ACL resource
+`Aplazo_AplazoPayment::aplazo_refund_queue`, nested under
+`Magento_Sales::creditmemo`), letting operators inspect queued/failed refunds.
+
+## Manual processing
+
+```bash
+php bin/magento aplazo:refund:process   # process the queue now (same as the 5-min cron)
+```
+
+See [Cron & CLI](cron-and-cli.md).

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,0 +1,75 @@
+# Troubleshooting
+
+Enable verbose logging first: **Activar logs = 2 (VVV)** and watch
+`var/log/aplazo_payments.log`. Remote logs (correlated by `request_id`) are also
+available to the platform team via Aplazo Core.
+
+## The Aplazo method doesn't show at checkout
+
+Check, in order:
+
+1. **Activar** = Yes (`payment/aplazo_gateway/active`).
+2. **Credentials valid** — `CredentialsValidator::areCredentialsValid()` requires both
+   a successful `POST /api/auth` **and** store currency `MXN`. The **Estado de
+   credenciales** and **Moneda configurada** badges show this in admin.
+3. Cache flushed after changing config (`bin/magento cache:flush`).
+4. Correct **Modo de pruebas** for the credentials you entered (sandbox creds won't
+   auth against production and vice-versa).
+
+## "No token returned" / authentication errors
+
+- Wrong Merchant ID / API token, or wrong environment.
+- The token is stored **encrypted**; if the Magento `crypt` key changed, re-enter the
+  token in admin to re-encrypt it.
+
+## Order stays `pending`, never confirmed
+
+The webhook probably didn't reach the store or failed JWT validation.
+
+1. Confirm Aplazo is calling `POST {base}/rest/default/V1/aplazo/callback`.
+2. **JWT validation** uses the **API token** as the HS512 key. A token mismatch
+   between admin config and what Aplazo signs with → `JWT Validation error` in the log.
+3. Check for varnish/full-page-cache in front of the REST endpoint.
+4. **Safety net:** the 15-min cancel-orders cron will still recover the order if the
+   loan is `OUTSTANDING` in Aplazo — verify Magento cron is running.
+
+## Order was cancelled but the customer actually paid
+
+- The cancel cron checks loan status before cancelling; a paid loan should be recovered
+  (`OUTSTANDING`). If it was cancelled anyway, look for `module:cron` logs around that
+  increment id — likely the loan-status call failed/timed out.
+- Orders that can't be cancelled cleanly are moved to `aplazo_order_canceled` to stop
+  endless cron retries.
+
+## Refund not reaching Aplazo
+
+1. Is **Habilitar reembolsos** (or **…por RMA**) enabled?
+2. Inspect the **Aplazo refund queue** grid / `aplazo_refund_request` table:
+   - `status = pending` with a future `next_attempt_at` → waiting on backoff.
+   - `status = failed` with `last_error` → inspect the error; `REJECTED` means Aplazo
+     declined it.
+3. Force a run: `php bin/magento aplazo:refund:process`.
+4. Duplicate refunds are impossible — the `(type, idempotency_key)` unique constraint +
+   `X-Idempotency-Key` header enforce at-most-once.
+
+## Cart not recovered after abandon
+
+- Requires **cancel_active** and **recover_active** enabled.
+- Recovery rebuilds a quote from the order's visible items; items missing
+  `info_buyRequest` options or deleted products are skipped and logged
+  (`Cart recovery failed: no recoverable items`).
+
+## Widgets not appearing on product/cart pages
+
+- `show_on_product_page` / `show_on_cart` must be enabled, and the module active with
+  valid credentials — the JS/widget loads only when the method is usable.
+
+## Useful commands
+
+```bash
+php bin/magento module:status Aplazo_AplazoPayment
+php bin/magento aplazo:orders:cancel     # run cancel-orders logic now
+php bin/magento aplazo:refund:process    # drain refund queue now
+tail -f var/log/aplazo_payments.log
+tail -f var/log/aplazo_payment/info.log  # health check output
+```

--- a/docs/src/webhooks.md
+++ b/docs/src/webhooks.md
@@ -1,0 +1,97 @@
+# Webhook & Callbacks
+
+The module exposes two REST endpoints (declared in `etc/webapi.xml`). Both are served
+under the Magento Web API base, e.g. `https://<store>/rest/default/V1/...`.
+
+## Payment confirmation webhook
+
+```
+POST /V1/aplazo/callback/
+Resource: anonymous
+Service:  Aplazo\AplazoPayment\Api\NotificationsInterface::notify
+```
+
+Called by Aplazo when a loan changes state. Request body maps to the interface
+parameters:
+
+| Param | Meaning |
+|-------|---------|
+| `loanId` | Aplazo loan identifier |
+| `status` | Loan status. `"Activo"` triggers order approval |
+| `cartId` | The Magento order **increment id** (used to locate the order) |
+
+### Security — JWT (HS512)
+
+Although the route is `anonymous`, every call is authenticated by a **JWT** in the
+`Authorization: Bearer <jwt>` header:
+
+```php
+JWT::decode($jwt, new Key($apiToken, 'HS512'));
+```
+
+- The signing key is the merchant's **API token** (the same secret configured in
+  admin, `payment/aplazo_gateway/apitoken`).
+- The **decoded JWT payload** — not the raw POST body — is the trusted source of
+  `loanId`, `status`, and `cartId`. Payload keys: `loanId`, `status`, `cartId`.
+- If decoding fails, the webhook returns `{ status: false, message: ... }` and takes
+  no action.
+
+### Processing logic
+
+```mermaid
+flowchart TD
+    A[POST /V1/aplazo/callback] --> B{Valid JWT?}
+    B -- no --> Z[Return status:false]
+    B -- yes --> C[Find order by increment id = cartId]
+    C -->|not found| Z
+    C -->|found| D{payload status == 'Activo'?}
+    D -- no --> E[No action, return OK]
+    D -- yes --> F[approveOrder → invoice]
+    F --> G[Store aplazo_payment_id + aplazo_status on payment]
+    G --> H{send_email enabled?}
+    H -- yes --> I[Send order confirmation email]
+    F --> J[trackOrderPaid event best-effort]
+    G --> K[Add comment to order status history]
+    K --> L[Return status:true]
+```
+
+Notes:
+
+- The webhook **advances the order to processing regardless of invoice creation**
+  problems (invoice failures are logged, not fatal).
+- Order confirmation email is sent **only** when `send_email` is enabled; otherwise
+  the default Magento new-order email is suppressed to avoid duplicates.
+- A status-history comment is added ("Notificación automática de Aplazo…").
+
+### Callback URL
+
+The callback URL the merchant registers with Aplazo is built by the module as:
+
+```
+{store base url}rest/default/V1/aplazo/callback
+```
+
+(`Helper\Data::getCallbackUrl()`).
+
+## Abandoned checkout
+
+```
+POST /V1/aplazo/checkout-not-paid
+Resource: Magento_Sales::cancel
+Service:  Aplazo\AplazoPayment\Api\CheckoutNotPaidManagementInterface::postCheckoutNotPaid
+```
+
+Invoked (via the frontend `Operations::cancel` action, guarded by the cancel token)
+when a shopper returns from the Aplazo checkout without paying. It:
+
+1. Cancels the order and clears the checkout session.
+2. If **recover cart** is enabled, rebuilds a new quote from the order's visible
+   items (preserving customer context and `info_buyRequest` options) and replaces the
+   session quote so the shopper can retry.
+3. Returns a message (`cancel_message`) and, on success, the new `quoteId`.
+
+!!! info "Why a cancel token?"
+    The redirect URL stored on the order is `"<aplazo url>||<random token>"`. The
+    `purchase` action uses the left side (the URL); the `cancel` action requires the
+    right side (the token) to match, preventing arbitrary third-party cancellation of
+    an order by increment id alone.


### PR DESCRIPTION
## BNPL-1018 — [Magento] Plugin documentation in Backstage

Parent: **BNPL-1001** (Engineering Transition — Plugins documentation)

Adds the Backstage Software Catalog entry and TechDocs for the Magento 2 / Adobe Commerce payment module so it is discoverable and consumable in the developer portal.

### What's included
- `catalog-info.yaml` — Backstage `Component` (owner, `system: bnpl-online`, `techdocs-ref: dir:./docs`)
- `docs/mkdocs.yml` — TechDocs config (`techdocs-core`)
- `docs/src/*.md` — index, getting started, configuration, checkout flow, webhooks, API reference, refunds & RMA, cron & CLI, data model, observability, troubleshooting

### Notes
- **Docs-only.** No module code changes and **no version bump**.
- All content is grounded in the current module source.
- Disjoint from any other in-flight code branches, so it merges independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and catalog metadata only; no runtime, payment, or deployment behavior changes.
> 
> **Overview**
> Registers the **aplazo-magento-2-payment-gateway** Composer module in Backstage via new **`catalog-info.yaml`** (`Component`, `techdocs-ref: dir:./docs`, owner **merchant-growth**, system **bnpl-online**, GitHub slug and merchant link).
> 
> Introduces **`docs/mkdocs.yml`** (TechDocs core, search, Mermaid) and **`docs/src/*.md`** — a full doc set (overview, install, admin config, checkout, JWT webhooks, API surface, refund queue/RMA, cron/CLI, schema, observability, troubleshooting) aimed at the developer portal.
> 
> **Docs-only:** no payment module changes and no version bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c4909b4a1d31d15c4b466d475a31dd7f9e48ab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->