### PR TITLE
MG-763: add DataDog inventory/stock logging (Magento)

### DIFF
--- a/Cron/CancelOrders.php
+++ b/Cron/CancelOrders.php
@@ -61,6 +61,7 @@ class CancelOrders
         $this->logService->resetRequestId();
         if($minutes = $this->aplazoHelper->getCancelTime()){
             $this->aplazoHelper->log('------ Cancelando ordenes ------');
+            $this->logService->send('info', 'Cron cancel orders: starting', ['module:cron'], ['cancel_time_minutes' => $minutes]);
             $orderCollection = $this->orderService->getOrderToCancelCollection($minutes);
             $counter = $ordersCanceledCount = 0;
             $ordersWithErrors = [];
@@ -74,6 +75,7 @@ class CancelOrders
                  }
                 $message = 'Total de ordenes encontradas: ' . $orderCollectionCount;
                 $this->aplazoHelper->log($message);
+                $this->logService->send('info', 'Cron cancel orders started', ['module:cron'], ['total_orders' => $orderCollectionCount]);
 
                 foreach ($orderCollection as $order) {
                     $store_id = $order->getStoreId();
@@ -103,6 +105,7 @@ class CancelOrders
                                 $order->addCommentToStatusHistory($message);
                                 $order = $this->orderService->saveOrder($order);
                                 $this->aplazoHelper->log("Order $incrementId is OUTSTANDING in Aplazo. Message > " . $message );
+                                $this->logService->send('info', 'Cron: order recovered (OUTSTANDING)', ['module:cron'], $this->apiService->getOrderImportantDataToLog($order));
                                 $recoveredIds[] = $incrementId;
                             } else {
                                 $message = 'Order incrementId not found ' . $incrementId;
@@ -119,6 +122,7 @@ class CancelOrders
                         if($cancelResponse['success']){
                             $message = "Aplazo Cancel Orders: StoreId $store_id - $counter/$orderCollectionCount - #$incrementId - Cancelada exitosamente";
                             $this->aplazoHelper->log($message);
+                            $this->logService->send('info', 'Cron: order cancelled', ['module:cron'], $this->apiService->getOrderImportantDataToLog($order));
                             $ordersCanceledCount++;
                             $cancelledIds[] = $incrementId;
                         } else {
@@ -138,33 +142,21 @@ class CancelOrders
 
     private function finish($ordersCanceledCount, $ordersWithErrors, $cancelledIds = [], $recoveredIds = [])
     {
-        $cancelledCount = $ordersCanceledCount;
-        $recoveredCount = count($recoveredIds);
-
-        if($cancelledCount == 0 && count($ordersWithErrors) == 0 && $recoveredCount == 0){
+        if($ordersCanceledCount == 0 && count($ordersWithErrors) == 0 && count($recoveredIds) == 0){
             $this->aplazoHelper->log("<comment>No se encontraron ordenes de Aplazo para cancelar</comment>");
-        } else {
+            $this->logService->send('info', 'Cron cancel orders finished: no orders to process', ['module:cron']);
+        }
+        else {
             $this->aplazoHelper->log('');
             $this->aplazoHelper->log("<info>Total cancelados: $ordersCanceledCount.</info>");
-
-            if ($cancelledCount > 0 && $recoveredCount > 0) {
-                $this->logService->send('info', 'Se cancelaron y recuperaron ordenes', ['module:cron'], [
-                    'cancelled_count' => $cancelledCount,
-                    'recovered_count' => $recoveredCount,
-                    'cancelled_orders' => $cancelledIds,
-                    'recovered_orders' => $recoveredIds,
-                ]);
-            } elseif ($cancelledCount > 0) {
-                $this->logService->send('info', 'Se cancelaron ordenes', ['module:cron'], [
-                    'cancelled_count' => $cancelledCount,
-                    'cancelled_orders' => $cancelledIds,
-                ]);
-            } elseif ($recoveredCount > 0) {
-                $this->logService->send('info', 'Se recuperaron ordenes', ['module:cron'], [
-                    'recovered_count' => $recoveredCount,
-                    'recovered_orders' => $recoveredIds,
-                ]);
-            }
+            $this->logService->send('info', 'Cron cancel orders finished', ['module:cron'], [
+                'total_cancelled' => $ordersCanceledCount,
+                'total_recovered' => count($recoveredIds),
+                'total_errors' => count($ordersWithErrors),
+                'cancelled_orders' => $cancelledIds,
+                'recovered_orders' => $recoveredIds,
+                'error_orders' => $ordersWithErrors
+            ]);
         }
 
         if(count($ordersWithErrors) > 0){

--- a/Model/CheckoutNotPaidManagement.php
+++ b/Model/CheckoutNotPaidManagement.php
@@ -66,6 +66,7 @@ class CheckoutNotPaidManagement implements CheckoutNotPaidManagementInterface
     public function postCheckoutNotPaid($incrementId)
     {
         $this->logService->resetRequestId();
+        $this->logService->send('info', 'Checkout not paid: processing', ['module:cancel'], ['increment_id' => $incrementId, 'recover_cart_enabled' => $this->aplazoHelper->getEnableRecoverCart() ? 'yes' : 'no']);
         $orderArray = $this->orderService->getOrderByIncrementId($incrementId);
         /** @var \Aplazo\AplazoPayment\Api\CheckoutNotPaidManagementResponseInterface $return */
         $return = $this->responseInterfaceFactory->create();
@@ -73,6 +74,7 @@ class CheckoutNotPaidManagement implements CheckoutNotPaidManagementInterface
             ->setQuoteId(null)
             ->setMessageError(null);
         if ($order = $orderArray['order']) {
+            $this->logService->send('info', 'Checkout not paid: cancelling order', ['module:cancel'], ['increment_id' => $incrementId, 'order_status' => $order->getStatus()]);
             $this->orderService->cancelOrder($order->getId());
             $this->checkoutSession->unsLastRealOrderId();
             $this->checkoutSession->clearHelperData();
@@ -91,6 +93,13 @@ class CheckoutNotPaidManagement implements CheckoutNotPaidManagementInterface
                     $newQuote->setCustomerGroupId($quote->getCustomerGroupId());
                     $newQuote->setCustomerIsGuest($quote->getCustomerIsGuest());
                     $newQuote->setIsActive(true);
+                    $this->logService->send('info', 'New quote created with customer context', ['module:cancel'], [
+                        'increment_id' => $incrementId,
+                        'old_quote_id' => $quoteId,
+                        'customer_id' => $quote->getCustomerId(),
+                        'customer_email' => $quote->getCustomerEmail(),
+                        'is_guest' => $quote->getCustomerIsGuest()
+                    ]);
                     $canRecoverQuote = false;
                     foreach ($quote->getAllVisibleItems() as $item) {
                         try{

--- a/Model/Notifications.php
+++ b/Model/Notifications.php
@@ -62,13 +62,16 @@ class Notifications implements NotificationsInterface
     {
         $this->logService->resetRequestId();
         $this->aplazoHelper->log("Webhook triggered.");
+        $this->logService->send('info', 'Webhook received', ['module:webhook'], ['loan_id' => $loanId, 'status' => $status, 'cart_id' => $cartId]);
         $response = ['status' => true, 'message' => 'OK'];
         if ($aplazoData = $this->validateJWT()) {
+            $this->logService->send('info', 'JWT validated, processing webhook payload', ['module:webhook'], ['payload_loan_id' => $aplazoData[self::APLAZO_PAYLOAD_LOAN_ID_INDEX] ?? '', 'payload_status' => $aplazoData[self::APLAZO_PAYLOAD_STATUS_INDEX] ?? '', 'payload_cart_id' => $aplazoData[self::APLAZO_PAYLOAD_ORDER_ID_INDEX] ?? '']);
             try {
                 $orderResult = $this->orderService->getOrderByIncrementId($aplazoData[self::APLAZO_PAYLOAD_ORDER_ID_INDEX]);
                 if ($orderResult['success']) {
                     /** @var Order $order */
                     $order = $orderResult['order'];
+                    $this->logService->send('info', 'Order found for webhook', ['module:webhook'], ['order_id' => $order->getIncrementId(), 'current_state' => $order->getState(), 'current_status' => $order->getStatus()]);
                     if ($status == 'Activo') {
                         $orderService = $this->orderService->approveOrder($order->getId());
                         $order = $orderService['order'];
@@ -77,6 +80,7 @@ class Notifications implements NotificationsInterface
                         }
                         if($this->aplazoHelper->getSendEmail()){
                             $this->orderSender->send($order, true);
+                            $this->logService->send('info', 'Order confirmation email sent', ['module:webhook'], ['order_id' => $order->getIncrementId()]);
                         }
                         $orderPayment = $order->getPayment();
                         $orderPayment->setAdditionalInformation('aplazo_payment_id', $aplazoData[self::APLAZO_PAYLOAD_LOAN_ID_INDEX]);

--- a/Model/Product/InventoryStock.php
+++ b/Model/Product/InventoryStock.php
@@ -2,6 +2,7 @@
 
 namespace Aplazo\AplazoPayment\Model\Product;
 
+use Aplazo\AplazoPayment\Service\LogService;
 use Magento\CatalogInventory\Api\StockConfigurationInterface;
 use Magento\InventoryApi\Api\Data\SourceItemInterface;
 use Magento\InventoryApi\Api\SourceItemRepositoryInterface;
@@ -11,12 +12,15 @@ class InventoryStock
 {
 
     private $stockRegistry;
+    private LogService $logService;
 
     public function __construct(
-        \Magento\CatalogInventory\Api\StockRegistryInterface $stockRegistry
+        \Magento\CatalogInventory\Api\StockRegistryInterface $stockRegistry,
+        LogService $logService
     )
     {
         $this->stockRegistry = $stockRegistry;
+        $this->logService = $logService;
     }
 
     /**
@@ -30,6 +34,7 @@ class InventoryStock
      */
     public function updateQtyNotMSI($order, $plus)
     {
+        $direction = $plus ? 'increase' : 'decrease';
         foreach ($order->getAllItems() as $item) {
             if($item->getProductType() == 'configurable'){
                 continue;
@@ -50,6 +55,16 @@ class InventoryStock
                 }
             }
             $stockItem->save();
+            $this->logService->send('info', "Legacy stock $direction for item", ['module:checkout', 'action:stock'], [
+                'order_id' => $order->getIncrementId(),
+                'product_id' => $item->getProductId(),
+                'sku' => $item->getSku(),
+                'name' => $item->getName(),
+                'qty_ordered' => $qtyOrdered,
+                'stock_before' => $stockBefore,
+                'stock_after' => (float)$stockItem->getQty(),
+                'is_in_stock' => $stockItem->getIsInStock()
+            ]);
         }
     }
 }

--- a/Model/Product/MSIStock.php
+++ b/Model/Product/MSIStock.php
@@ -2,6 +2,7 @@
 
 namespace Aplazo\AplazoPayment\Model\Product;
 
+use Aplazo\AplazoPayment\Service\LogService;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
@@ -35,6 +36,7 @@ class MSIStock
     private $salesEventFactory;
     private $salesChannelFactory;
     private $placeReservationsForSalesEvent;
+    private LogService $logService;
 
     public function __construct(
         GetSkusByProductIdsInterface                         $getSkusByProductIds,
@@ -47,7 +49,8 @@ class MSIStock
         SalesEventExtensionFactory                           $salesEventExtensionFactory,
         SalesEventInterfaceFactory                           $salesEventFactory,
         SalesChannelInterfaceFactory                         $salesChannelFactory,
-        PlaceReservationsForSalesEventInterface              $placeReservationsForSalesEvent
+        PlaceReservationsForSalesEventInterface              $placeReservationsForSalesEvent,
+        LogService                                           $logService
     )
     {
         $this->getSkusByProductIds = $getSkusByProductIds;
@@ -61,6 +64,7 @@ class MSIStock
         $this->salesEventFactory = $salesEventFactory;
         $this->salesChannelFactory = $salesChannelFactory;
         $this->placeReservationsForSalesEvent = $placeReservationsForSalesEvent;
+        $this->logService = $logService;
     }
 
     /**
@@ -75,12 +79,15 @@ class MSIStock
      */
     public function updateQty($order, $plus, $type)
     {
+        $direction = $plus ? 'increase' : 'decrease';
         $itemsById = $itemsBySku = $itemsToSell = [];
+        $itemNames = [];
         foreach ($order->getItems() as $item) {
             if (!isset($itemsById[$item->getProductId()])) {
                 $itemsById[$item->getProductId()] = 0;
             }
             $itemsById[$item->getProductId()] += $item->getQtyOrdered();
+            $itemNames[$item->getProductId()] = $item->getName();
         }
         $productSkus = $this->getSkusByProductIds->execute(array_keys($itemsById));
         $productTypes = $this->getProductTypesBySkus->execute($productSkus);
@@ -95,6 +102,14 @@ class MSIStock
             $itemsToSell[] = $this->itemsToSellFactory->create([
                 'sku' => $sku,
                 'qty' => $reservationQty
+            ]);
+            $this->logService->send('info', "MSI reservation $direction for item", ['module:checkout', 'action:stock'], [
+                'order_id' => $order->getIncrementId(),
+                'product_id' => $productId,
+                'sku' => $sku,
+                'name' => $itemNames[$productId] ?? '',
+                'qty_ordered' => (float)$itemsById[$productId],
+                'reservation_qty' => $reservationQty
             ]);
         }
 

--- a/Model/RefundQueueManagement.php
+++ b/Model/RefundQueueManagement.php
@@ -59,6 +59,7 @@ class RefundQueueManagement implements RefundQueueManagementInterface
             $this->refundRequestRepository->save($request);
 
             $payload = json_decode($request->getPayloadJson(), true) ?: [];
+            $this->logService->send('info', 'Processing refund from queue', ['module:refund'], ['order_id' => $request->getOrderIncrementId(), 'amount_cents' => $request->getAmountCents(), 'attempt' => $request->getRetries() + 1]);
             $response = $this->apiService->createRefund($payload, $request->getIdempotencyKey());
             $this->handleRefundResponse($request, $response);
         } catch (\Throwable $e) {

--- a/Model/Service/OrderService.php
+++ b/Model/Service/OrderService.php
@@ -98,9 +98,16 @@ class OrderService
     public function reservingStockUntilPayment($order, $type = SalesEventInterface::EVENT_ORDER_PLACED)
     {
         $reserveStockEnabled = $this->aplazoHelper->getReserveStock();
+        $this->logService->send('info', 'reservingStockUntilPayment called', ['module:checkout', 'action:stock'], [
+            'order_id' => $order->getIncrementId(),
+            'reserve_stock_config' => $reserveStockEnabled ? 'yes' : 'no',
+            'operation' => 'restore (plus)',
+            'type' => $type
+        ]);
         if ($reserveStockEnabled) {
             try {
                 $this->isMsiOrInventory($order, true, 'aplazo_item_reserved');
+                $this->logService->send('info', 'Stock reservation restored successfully', ['module:checkout', 'action:stock'], ['order_id' => $order->getIncrementId()]);
             } catch (\Exception $e) {
                 $message = 'Webhook error inventory: Al crear pedido no se recupero la reserva de stock. Increment_id ' . $order->getIncrementId();
                 $this->aplazoHelper->log($message);
@@ -116,9 +123,16 @@ class OrderService
     public function decreasingStockAfterPaymentSuccess($order, $type = SalesEventInterface::EVENT_ORDER_CANCELED)
     {
         $reserveStockEnabled = $this->aplazoHelper->getReserveStock();
+        $this->logService->send('info', 'decreasingStockAfterPaymentSuccess called', ['module:webhook', 'action:stock'], [
+            'order_id' => $order->getIncrementId(),
+            'reserve_stock_config' => $reserveStockEnabled ? 'yes' : 'no',
+            'operation' => 'decrease (minus)',
+            'type' => $type
+        ]);
         if ($reserveStockEnabled) {
             try {
                 $this->isMsiOrInventory($order, false, $type);
+                $this->logService->send('info', 'Stock decreased successfully after payment', ['module:webhook', 'action:stock'], ['order_id' => $order->getIncrementId(), 'type' => $type]);
             } catch (\Exception $e) {
                 $message = 'Webhook error inventory: Al crear invoice no se pudo reservar stock. Increment_id ' . $order->getIncrementId();
                 $this->aplazoHelper->log($message);
@@ -130,18 +144,29 @@ class OrderService
 
     public function isMsiOrInventory($order, $plus, $type = ''){
         $msiEnabled = $this->manager->isEnabled("Magento_Inventory") && $this->manager->isEnabled("Magento_InventoryCatalogApi");
+        $direction = $plus ? 'increase' : 'decrease';
+        $this->logService->send('info', "Stock update: $direction via " . ($msiEnabled ? 'MSI' : 'legacy'), ['module:checkout', 'action:stock'], [
+            'order_id' => $order->getIncrementId(),
+            'msi_enabled' => $msiEnabled,
+            'direction' => $direction,
+            'type' => $type,
+            'items_count' => count($order->getItems())
+        ]);
         if($msiEnabled){
             try{
                 $msiStock = \Magento\Framework\App\ObjectManager::getInstance()->get(\Aplazo\AplazoPayment\Model\Product\MSIStock::class);
                 $msiStock->updateQty($order, $plus, $type);
+                $this->logService->send('info', "MSI stock updated ($direction)", ['module:checkout', 'action:stock'], ['order_id' => $order->getIncrementId()]);
             } catch (\Exception $e){
                 $this->logService->send('warn', 'MSI stock failed, falling back to legacy inventory: ' . $e->getMessage(), ['module:checkout', 'action:stock'], ['order_id' => $order->getIncrementId()]);
                 $inventoryStock = \Magento\Framework\App\ObjectManager::getInstance()->get(\Aplazo\AplazoPayment\Model\Product\InventoryStock::class);
                 $inventoryStock->updateQtyNotMSI($order, $plus);
+                $this->logService->send('info', "Legacy inventory stock updated ($direction) after MSI fallback", ['module:checkout', 'action:stock'], ['order_id' => $order->getIncrementId()]);
             }
         } else {
             $inventoryStock = \Magento\Framework\App\ObjectManager::getInstance()->get(\Aplazo\AplazoPayment\Model\Product\InventoryStock::class);
             $inventoryStock->updateQtyNotMSI($order, $plus);
+            $this->logService->send('info', "Legacy inventory stock updated ($direction)", ['module:checkout', 'action:stock'], ['order_id' => $order->getIncrementId()]);
         }
     }
 
@@ -303,6 +328,7 @@ class OrderService
         $order = $this->orderRepository->get($orderId);
         $message = '';
         $orderData = $this->aplazoService->getOrderImportantDataToLog($order);
+        $this->logService->send('info', 'approveOrder started', ['module:webhook'], $orderData);
         $this->decreasingStockAfterPaymentSuccess($order, 'order_placed_aplazo');
         if (!$this->invoiceOrder($order)) {
             $message = 'Orden no se puede hacer invoice ' . $order->getIncrementId();
@@ -330,6 +356,7 @@ class OrderService
     {
         if ($order->canInvoice()) {
             try {
+                $this->logService->send('info', 'Creating invoice for order', ['module:webhook'], ['order_id' => $order->getIncrementId(), 'state' => $order->getState(), 'status' => $order->getStatus()]);
                 $invoice = $this->invoiceService->prepareInvoice($order);
                 $invoice->setRequestedCaptureCase(\Magento\Sales\Model\Order\Invoice::CAPTURE_ONLINE);
                 $invoice->register();
@@ -337,6 +364,7 @@ class OrderService
                     ->addObject($invoice)
                     ->addObject($invoice->getOrder());
                 $transaction->save();
+                $this->logService->send('info', 'Invoice created successfully', ['module:webhook'], ['order_id' => $order->getIncrementId(), 'invoice_id' => $invoice->getIncrementId()]);
             } catch (\Exception $e) {
                 $message = 'Error al crear el invoice de la orden ' . $order->getIncrementId() . ' mensaje de error > ' . $e->getMessage();
                 $this->aplazoHelper->log($message);
@@ -358,14 +386,17 @@ class OrderService
         $result = ['success' => false, 'message' => ''];
         try {
             $order = $this->orderRepository->get($orderId);
+            $this->logService->send('info', 'cancelOrder called', ['module:cancel'], ['order_id' => $order->getIncrementId(), 'entity_id' => $orderId, 'state' => $order->getState(), 'status' => $order->getStatus()]);
             if ($order->canCancel()) {
                 $order->cancel();
                 $result['success'] = true;
                 $result['message'] = __("Order successfully canceled");
+                $this->logService->send('info', 'Order cancelled successfully', ['module:cancel'], ['order_id' => $order->getIncrementId()]);
             } else {
                 if ($order->isCanceled()) {
                     $result['success'] = true;
                     $result['message'] = __("Order already canceled");
+                    $this->logService->send('info', 'Order was already cancelled', ['module:cancel'], ['order_id' => $order->getIncrementId()]);
                 } else {
                     $result['message'] = __("Can not cancel this orden");
                     $this->logService->send('warn', 'Order cannot be cancelled', ['module:cancel'], ['order_id' => $order->getIncrementId(), 'state' => $order->getState(), 'status' => $order->getStatus()]);

--- a/Observer/Order/CancelAfter.php
+++ b/Observer/Order/CancelAfter.php
@@ -52,6 +52,7 @@ class CancelAfter implements \Magento\Framework\Event\ObserverInterface
         $order = $observer->getEvent()->getOrder();
 
         if($order->getPayment()->getMethod() === ConfigProvider::CODE){
+            $this->logService->send('info', 'Order cancel after: cancelling loan and updating stock', ['module:cancel'], ['order_id' => $order->getIncrementId(), 'state' => $order->getState(), 'status' => $order->getStatus()]);
             $this->orderService->decreasingStockAfterPaymentSuccess($order, 'order_canceled_aplazo');
             try{
                 $this->aplazoService->cancelLoan([
@@ -59,6 +60,7 @@ class CancelAfter implements \Magento\Framework\Event\ObserverInterface
                     "totalAmount" => 0,
                     "reason" => 'No payment'
                 ]);
+                $this->logService->send('info', 'Loan cancelled via API', ['module:cancel'], ['order_id' => $order->getIncrementId()]);
             } catch (LocalizedException $e) {
                 $this->logService->send('error', 'Cancel loan API failed: ' . $e->getMessage(), ['module:cancel'], ['order_id' => $order->getIncrementId()]);
             }

--- a/Observer/RefundObserverBeforeSave.php
+++ b/Observer/RefundObserverBeforeSave.php
@@ -90,6 +90,7 @@ class RefundObserverBeforeSave implements ObserverInterface
             $reason .=  $index . '. ' . $comment->getComment() . '.  ';
         }
 
+        $this->_logService->send('info', 'Credit memo refund started', ['module:refund'], ['order_id' => $order->getIncrementId(), 'amount' => $amountRefund, 'order_total' => $order->getGrandTotal()]);
         $response = $this->_aplazoService->createRefund([
             "cartId"        => $order->getIncrementId(),
             "totalAmount"   => $amountRefund,

--- a/Observer/RmaObserverBeforeSave.php
+++ b/Observer/RmaObserverBeforeSave.php
@@ -73,6 +73,8 @@ class RmaObserverBeforeSave implements ObserverInterface
         $itemFactory = \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Rma\Model\ItemFactory::class);
         $order_increment_id = $rma->getOrderIncrementId();
         $items = $rma->getItems();
+        $this->_logService->send('info', 'RMA refund processing started', ['module:refund'], ['order_id' => $order_increment_id, 'rma_id' => $rma->getId(), 'items_count' => count($items)]);
+
         foreach($items as $item){
             if($item->getResolution() == self::RMA_REFUND_RESOLUTION && $item->getStatus() == \Magento\Rma\Model\Rma\Source\Status::STATE_APPROVED){
                 /** @var \Magento\Rma\Model\Item $item_model */

--- a/Observer/SalesOrderPlaceAfterCreateLoan.php
+++ b/Observer/SalesOrderPlaceAfterCreateLoan.php
@@ -46,12 +46,14 @@ class SalesOrderPlaceAfterCreateLoan implements ObserverInterface
             } catch (\Throwable $e) {
                 // Never block order placement because of tracking.
             }
+            $this->logService->send('info', 'Order placed, creating loan', ['module:checkout'], ['order_id' => $order->getIncrementId(), 'grand_total' => (float)$order->getGrandTotal()]);
             $result = $this->orderService->createLoan($order, $randomToken);
             if(!empty($result['url'])){
                 $order->setStatus($this->aplazoHelper->getNewOrderStatus());
                 $aplazoCheckoutUrl = empty($randomToken) ? $result['url'] : $result['url'] . '||' . $randomToken;
                 $order->setAplazoCheckoutUrl($aplazoCheckoutUrl);
                 $this->aplazoHelper->log('Se guarda la url de Aplazo en la orden: '. $aplazoCheckoutUrl, AplazoHelper::LOGS_VVV);
+                $this->logService->send('info', 'Loan URL assigned to order', ['module:checkout'], ['order_id' => $order->getIncrementId()]);
             } else {
                 $this->logService->send('error', 'Loan creation returned no URL', ['module:checkout'], ['order_id' => $order->getIncrementId()]);
             }

--- a/Service/ApiService.php
+++ b/Service/ApiService.php
@@ -67,6 +67,7 @@ class ApiService
      */
     public function createRefund($orderData, ?string $idempotencyKey = null)
     {
+        $this->logService->send('info', 'API createRefund request', ['module:refund'], ['cart_id' => $orderData['cartId'] ?? '', 'amount' => $orderData['totalAmount'] ?? '', 'has_idempotency' => !empty($idempotencyKey)]);
         $response = $this->requestService(
             $this->getRefundLoanUrl(),
             json_encode($orderData),
@@ -74,6 +75,7 @@ class ApiService
             false,
             $idempotencyKey ? ['X-Idempotency-Key' => $idempotencyKey] : []
         );
+        $this->logService->send('info', 'API createRefund response received', ['module:refund'], ['cart_id' => $orderData['cartId'] ?? '']);
 
         return $response;
     }
@@ -85,10 +87,12 @@ class ApiService
      */
     public function cancelLoan($orderData)
     {
+        $this->logService->send('info', 'API cancelLoan request', ['module:cancel'], ['cart_id' => $orderData['cartId'] ?? '', 'reason' => $orderData['reason'] ?? '']);
         $response = $this->requestService(
             $this->getCancelLoanUrl(),
             json_encode($orderData)
         );
+        $this->logService->send('info', 'API cancelLoan response received', ['module:cancel'], ['cart_id' => $orderData['cartId'] ?? '']);
 
         return $response;
     }
@@ -132,15 +136,19 @@ class ApiService
 
     public function shouldCancelOrder($cartId)
     {
+        $this->logService->send('info', 'Checking loan status for cancel decision', ['module:cron'], ['cart_id' => $cartId]);
         $response = $this->getLoanStatus($cartId);
         if(is_array($response)){
+            $this->logService->send('info', 'Loan status response received', ['module:cron'], ['cart_id' => $cartId, 'loans_count' => count($response)]);
             foreach ($response as $index => $loan) {
                 if (isset($loan['status'])) {
                     if ($loan['status'] === self::LOAN_SUCCESS_STATUS) {
                         $this->aplazoHelper->log("Loan status for index [$index] is OUTSTANDING. Cart ID $cartId must not be cancelled.");
+                        $this->logService->send('info', "Loan [$index] is OUTSTANDING, order should NOT be cancelled", ['module:cron'], ['cart_id' => $cartId, 'loan_status' => $loan['status']]);
                         return true;
                     }
                     $this->aplazoHelper->log("Loan status is for index [$index] " . $loan['status'] . ". Cart ID $cartId must be cancelled.");
+                    $this->logService->send('info', "Loan [$index] status: " . $loan['status'], ['module:cron'], ['cart_id' => $cartId, 'loan_status' => $loan['status']]);
                 } else {
                     $this->aplazoHelper->log("Loan not found. Cart ID $cartId must be cancelled.");
                     $this->logService->send('warn', "Loan [$index] has no status field", ['module:cron'], ['cart_id' => $cartId]);


### PR DESCRIPTION
## MG-763 — Ampliar cobertura de logs en DataDog (Magento)

Adds DataDog log coverage for inventory/stock events and movements in the Magento plugin, plus finer-grained logging across cron, observers, and the order/API services.

### What's included
- Stock/inventory logging in `Model/Product/{InventoryStock,MSIStock}.php` and `Model/Service/OrderService.php` (reserve / decrease / MSI vs legacy)
- Logging in `Cron/CancelOrders.php`, `Model/CheckoutNotPaidManagement.php`, `Model/Notifications.php`, observers and `Service/ApiService.php`

### Notes
- Rebased on top of `master` (**v4.0.11**, includes MG-942 display-amounts): this PR **only adds logging** — no version bump and no changes to currency/amount behavior.
- Net diff: +108 / −26 across 12 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive logging only; no payment, stock, or order state logic is altered. Some new checkout-cancel logs may include customer email for cart recovery debugging.
> 
> **Overview**
> Expands **DataDog** (`LogService::send`) coverage across the Magento Aplazo payment plugin so checkout, cancel, webhook, refund, cron, and stock paths emit structured logs with module tags (`module:cron`, `module:webhook`, `action:stock`, etc.) and contextual attributes.
> 
> **Inventory/stock** gets the deepest new instrumentation: `InventoryStock` and `MSIStock` now depend on `LogService` and log each line-item change (SKU, qty, before/after or reservation qty). `OrderService` logs reserve/decrease entry points, MSI vs legacy routing, MSI fallback, and success paths around `approveOrder`, `invoiceOrder`, and `cancelOrder`.
> 
> **Operational flows** gain step-level logs in the cancel cron (start, batch size, per-order cancel/recover, unified finish summary with cancelled/recovered/error lists), checkout-not-paid (including quote recovery with customer context), webhooks (`Notifications`), loan placement observer, cancel-after observer, refund queue/credit memo/RMA, and `ApiService` for `createRefund`, `cancelLoan`, and cron loan-status decisions.
> 
> The cancel cron **finish** summary is simplified from separate Spanish-titled aggregate events to a single English finish event that also includes `total_errors` and `error_orders`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b9ab5676fa88e575fede519c76419ca28116c24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->